### PR TITLE
Feat/auth api/#15

### DIFF
--- a/apis/api-client.ts
+++ b/apis/api-client.ts
@@ -1,27 +1,46 @@
+import { useAuthStore } from "@/store/use-auth-store";
 import ky, { Options, ResponsePromise } from "ky";
+import { refreshAccessToken } from "./auth";
 
 const rawBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
 if (!rawBaseUrl) {
   throw new Error("NEXT_PUBLIC_API_BASE_URL is not defined");
 }
-const API_BASE_URL = `${rawBaseUrl.replace(/\/+$/, "")}/api/`;
+export const API_BASE_URL = `${rawBaseUrl.replace(/\/+$/, "")}/api/`;
+
+let refreshPromise: Promise<string | null> | null = null;
 
 const http = ky.create({
   prefixUrl: API_BASE_URL,
   timeout: 10000,
   retry: 0,
   credentials: "include",
-  headers: {
-    "Content-Type": "application/json",
-  },
   hooks: {
-    // 요청 전 처리 (예: Authorization 헤더에 토큰 자동 주입)
-    beforeRequest: [],
+    beforeRequest: [
+      (request) => {
+        const accessToken = useAuthStore.getState().accessToken;
+        if (accessToken) {
+          request.headers.set("Authorization", `Bearer ${accessToken}`);
+        }
+      },
+    ],
+    afterResponse: [
+      async (request, options, response) => {
+        if (response.status !== 401) return;
 
-    //공통 응답 처리 (예: 401 시 토큰 갱신 또는 로그아웃)
-    afterResponse: [],
+        if (!refreshPromise) {
+          refreshPromise = refreshAccessToken().finally(() => {
+            refreshPromise = null;
+          });
+        }
 
-    // 에러 응답 파싱 및 커스텀 에러 객체 생성
+        const newAccessToken = await refreshPromise;
+        if (!newAccessToken) return;
+
+        request.headers.set("Authorization", `Bearer ${newAccessToken}`);
+        return ky(request, options);
+      },
+    ],
     beforeError: [],
   },
 });
@@ -39,14 +58,27 @@ export const httpClient = {
     parseResponse<T>(http.get(normalizePath(url), options)),
 
   post: <T>(url: string, body?: unknown, options?: Options) =>
-    parseResponse<T>(http.post(normalizePath(url), { json: body, ...options })),
+    parseResponse<T>(
+      http.post(normalizePath(url), {
+        ...(body !== undefined && { json: body }),
+        ...options,
+      }),
+    ),
 
   put: <T>(url: string, body?: unknown, options?: Options) =>
-    parseResponse<T>(http.put(normalizePath(url), { json: body, ...options })),
+    parseResponse<T>(
+      http.put(normalizePath(url), {
+        ...(body !== undefined && { json: body }),
+        ...options,
+      }),
+    ),
 
   patch: <T>(url: string, body?: unknown, options?: Options) =>
     parseResponse<T>(
-      http.patch(normalizePath(url), { json: body, ...options }),
+      http.patch(normalizePath(url), {
+        ...(body !== undefined && { json: body }),
+        ...options,
+      }),
     ),
 
   delete: <T>(url: string, options?: Options) =>

--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -5,36 +5,42 @@ import {
   CheckDuplicateResponse,
   LoginResponse,
   LogoutResponse,
-  RefreshTokenResponse,
   SignupResponse,
 } from "@/types/response";
 import ky from "ky";
-import { API_BASE_URL, httpClient } from "./api-client";
+import { httpClient } from "./api-client";
+
+// 인증 BFF(Next.js Route Handler) 전용 same-origin 클라이언트.
+// refreshToken HttpOnly 쿠키 송수신을 위해 credentials를 포함하고,
+// logout 등에서 accessToken을 Authorization으로 실어 보낸다.
+const authClient = ky.create({
+  prefixUrl: "/api/auth",
+  timeout: 10000,
+  retry: 0,
+  credentials: "include",
+  hooks: {
+    beforeRequest: [
+      (request) => {
+        const accessToken = useAuthStore.getState().accessToken;
+        if (accessToken) {
+          request.headers.set("Authorization", `Bearer ${accessToken}`);
+        }
+      },
+    ],
+  },
+});
 
 export async function refreshAccessToken(): Promise<string | null> {
-  const refreshToken = useAuthStore.getState().refreshToken;
-  if (!refreshToken) return null;
-
   try {
-    const res = await ky
-      .post(API_BASE_URL + ENDPOINTS.REFRESH, {
-        json: { refreshToken },
-      })
-      .json<RefreshTokenResponse>();
+    // refreshToken은 HttpOnly 쿠키에 있으므로 바디 없이 호출한다.
+    const res = await authClient.post("refresh").json<{ accessToken: string }>();
 
-    const newAccessToken = res.accessToken;
-    useAuthStore.getState().setAuth({
-      ...useAuthStore.getState(),
-      accessToken: newAccessToken,
-    });
-    return newAccessToken;
+    const { setAuth, ...state } = useAuthStore.getState();
+    setAuth({ ...state, accessToken: res.accessToken });
+    return res.accessToken;
   } catch {
-    useAuthStore.getState().setAuth({
-      accessToken: "",
-      refreshToken: "",
-      isFirstLogin: false,
-      isDuplicateLogin: false,
-    });
+    const { setAuth } = useAuthStore.getState();
+    setAuth({ accessToken: "", isFirstLogin: false, isDuplicateLogin: false });
     return null;
   }
 }
@@ -47,7 +53,8 @@ export const checkDuplicate = (type: string, args: string) =>
 export const signup = (data: SignupRequest) =>
   httpClient.post<SignupResponse>(ENDPOINTS.SIGNUP, data);
 
+// 로그인/로그아웃은 BFF 라우트를 거쳐 refreshToken 쿠키를 관리한다.
 export const login = (data: LoginRequest) =>
-  httpClient.post<LoginResponse>(ENDPOINTS.LOGIN, data);
+  authClient.post("login", { json: data }).json<LoginResponse>();
 
-export const logout = () => httpClient.post<LogoutResponse>(ENDPOINTS.LOGOUT);
+export const logout = () => authClient.post("logout").json<LogoutResponse>();

--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -1,0 +1,53 @@
+import { ENDPOINTS } from "@/constants/endpoints";
+import { useAuthStore } from "@/store/use-auth-store";
+import { LoginRequest, SignupRequest } from "@/types/request";
+import {
+  CheckDuplicateResponse,
+  LoginResponse,
+  LogoutResponse,
+  RefreshTokenResponse,
+  SignupResponse,
+} from "@/types/response";
+import ky from "ky";
+import { API_BASE_URL, httpClient } from "./api-client";
+
+export async function refreshAccessToken(): Promise<string | null> {
+  const refreshToken = useAuthStore.getState().refreshToken;
+  if (!refreshToken) return null;
+
+  try {
+    const res = await ky
+      .post(API_BASE_URL + ENDPOINTS.REFRESH, {
+        json: { refreshToken },
+      })
+      .json<RefreshTokenResponse>();
+
+    const newAccessToken = res.accessToken;
+    useAuthStore.getState().setAuth({
+      ...useAuthStore.getState(),
+      accessToken: newAccessToken,
+    });
+    return newAccessToken;
+  } catch {
+    useAuthStore.getState().setAuth({
+      accessToken: "",
+      refreshToken: "",
+      isFirstLogin: false,
+      isDuplicateLogin: false,
+    });
+    return null;
+  }
+}
+
+export const checkDuplicate = (type: string, args: string) =>
+  httpClient.get<CheckDuplicateResponse>(
+    `${ENDPOINTS.SIGNUP}/check-${type}?${type}=${args}`,
+  );
+
+export const signup = (data: SignupRequest) =>
+  httpClient.post<SignupResponse>(ENDPOINTS.SIGNUP, data);
+
+export const login = (data: LoginRequest) =>
+  httpClient.post<LoginResponse>(ENDPOINTS.LOGIN, data);
+
+export const logout = () => httpClient.post<LogoutResponse>(ENDPOINTS.LOGOUT);

--- a/app/api/auth/_lib.ts
+++ b/app/api/auth/_lib.ts
@@ -1,0 +1,23 @@
+// 인증 BFF Route Handler 공용 설정 (서버 전용).
+// 파일명이 route.ts가 아니므로 라우트로 취급되지 않는다.
+
+const rawBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+if (!rawBase) {
+  throw new Error("NEXT_PUBLIC_API_BASE_URL is not defined");
+}
+
+// 실제 백엔드 API 베이스 (apis/api-client.ts의 API_BASE_URL과 동일 규칙).
+export const BACKEND_API = `${rawBase.replace(/\/+$/, "")}/api`;
+
+export const REFRESH_COOKIE = "refreshToken";
+
+// 백엔드 refreshToken TTL(10일)과 동일하게 맞춘다.
+export const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 10;
+
+// refresh/logout 라우트에서만 쿠키가 전송되도록 path를 좁힌다.
+export const refreshCookieOptions = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/api/auth",
+};

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,37 @@
+import { BackendLoginResponse } from "@/types/response";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  BACKEND_API,
+  REFRESH_COOKIE,
+  REFRESH_TOKEN_MAX_AGE,
+  refreshCookieOptions,
+} from "../_lib";
+
+// 브라우저 로그인 요청을 백엔드로 중계하고, 백엔드가 바디로 내려준 refreshToken을
+// HttpOnly 쿠키로 옮긴 뒤 나머지(accessToken 등)만 브라우저에 반환한다.
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  const upstream = await fetch(`${BACKEND_API}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store", // 인증 응답은 절대 캐시하지 않는다.
+  });
+
+  const data = await upstream.json();
+
+  // 실패 응답은 상태코드/바디를 그대로 전달해 클라이언트의 에러 처리를 유지한다.
+  if (!upstream.ok) {
+    return NextResponse.json(data, { status: upstream.status });
+  }
+
+  const { refreshToken, ...rest } = data as BackendLoginResponse;
+
+  const res = NextResponse.json(rest);
+  res.cookies.set(REFRESH_COOKIE, refreshToken, {
+    ...refreshCookieOptions,
+    maxAge: REFRESH_TOKEN_MAX_AGE,
+  });
+  return res;
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { BACKEND_API, REFRESH_COOKIE, refreshCookieOptions } from "../_lib";
+
+// 백엔드 로그아웃을 best-effort로 호출하고, 어떤 경우에도 HttpOnly 쿠키를 제거한다.
+export async function POST(req: NextRequest) {
+  const authorization = req.headers.get("authorization");
+
+  await fetch(`${BACKEND_API}/auth/logout`, {
+    method: "POST",
+    headers: authorization ? { authorization } : undefined,
+    cache: "no-store", // 인증 응답은 절대 캐시하지 않는다.
+  }).catch(() => {});
+
+  const res = NextResponse.json({ success: true });
+  res.cookies.delete({ name: REFRESH_COOKIE, path: refreshCookieOptions.path });
+  return res;
+}

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { BACKEND_API, REFRESH_COOKIE, refreshCookieOptions } from "../_lib";
+
+// HttpOnly 쿠키의 refreshToken을 꺼내 백엔드 refresh(바디 기반 계약)로 중계하고,
+// 새 accessToken만 브라우저에 반환한다.
+export async function POST(req: NextRequest) {
+  const refreshToken = req.cookies.get(REFRESH_COOKIE)?.value;
+  if (!refreshToken) {
+    return NextResponse.json(
+      { success: false, message: "no refresh token" },
+      { status: 401 },
+    );
+  }
+
+  const upstream = await fetch(`${BACKEND_API}/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+    cache: "no-store", // 인증 응답은 절대 캐시하지 않는다.
+  });
+
+  const data = await upstream.json();
+
+  // 갱신 실패(만료/무효) 시 죽은 쿠키를 제거한다.
+  if (!upstream.ok) {
+    const res = NextResponse.json(data, { status: upstream.status });
+    res.cookies.delete({ name: REFRESH_COOKIE, path: refreshCookieOptions.path });
+    return res;
+  }
+
+  return NextResponse.json({ accessToken: data.accessToken });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import QueryProvider from "@/apis/query-provider";
+import Modal from "@/components/common/modal";
 import "@/styles/globals.css";
 import type { Metadata } from "next";
 
@@ -15,7 +16,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="font-sans">
-        <QueryProvider>{children}</QueryProvider>
+        <QueryProvider>
+          {children}
+          <Modal />
+        </QueryProvider>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import QueryProvider from "@/apis/query-provider";
 import Modal from "@/components/common/modal";
+import AuthProvider from "@/components/providers/auth-provider";
 import "@/styles/globals.css";
 import type { Metadata } from "next";
 
@@ -17,8 +18,10 @@ export default function RootLayout({
     <html lang="ko">
       <body className="font-sans">
         <QueryProvider>
-          {children}
-          <Modal />
+          <AuthProvider>
+            {children}
+            <Modal />
+          </AuthProvider>
         </QueryProvider>
       </body>
     </html>

--- a/components/auth/login-form/index.tsx
+++ b/components/auth/login-form/index.tsx
@@ -4,29 +4,13 @@ import MainLogo from "@/assets/icons/main-logo.svg";
 import Button from "@/components/common/button";
 import HelperText from "@/components/common/helper-text";
 import InputField from "@/components/common/input-field";
+import { useLogin } from "@/hooks/queries/use-login";
+import { LoginFormData, loginSchema } from "@/schemas/login";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
-import z from "zod";
 
 export default function LoginForm() {
-  const loginSchema = z.object({
-    email: z
-      .string()
-      .min(1, "이메일을 입력해 주세요.")
-      .email("이메일 형식으로 작성해 주세요."),
-    password: z
-      .string()
-      .min(1, "비밀번호를 입력해 주세요.")
-      .min(8, "비밀번호는 8자 이상, 영문과 숫자 조합이어야 합니다.")
-      .regex(
-        /^(?=.*[a-zA-Z])(?=.*\d)/,
-        "비밀번호는 8자 이상, 영문과 숫자 조합이어야 합니다.",
-      ),
-  });
-
-  type LoginFormData = z.infer<typeof loginSchema>;
-
   const {
     register,
     handleSubmit,
@@ -40,8 +24,10 @@ export default function LoginForm() {
     },
   });
 
+  const { mutate: loginMutate, isPending } = useLogin();
+
   const handleClickSubmit = (data: LoginFormData) => {
-    // TODO: 로그인 API 연동
+    loginMutate(data);
   };
 
   return (
@@ -86,7 +72,7 @@ export default function LoginForm() {
             value="로그인"
             variant="Primary"
             type="submit"
-            disabled={!isValid}
+            disabled={!isValid || isPending}
           />
           <Link
             href="/signup"

--- a/components/auth/signup-form/duplicated-check-field/index.tsx
+++ b/components/auth/signup-form/duplicated-check-field/index.tsx
@@ -1,5 +1,8 @@
 import Button from "@/components/common/button";
+import HelperText from "@/components/common/helper-text";
 import InputField from "@/components/common/input-field";
+import { useCheckDuplicate } from "@/hooks/queries/use-check-duplicate";
+import { cn } from "@/utils/cn";
 import { useFormContext } from "react-hook-form";
 
 interface DuplicatedCheckFieldProps {
@@ -15,12 +18,38 @@ export default function DuplicatedCheckField({
   label,
   placeholder,
 }: DuplicatedCheckFieldProps) {
-  const { register } = useFormContext();
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext();
 
-  const handleDuplicateClick = async (type: string) => {
-    // 이메일이나 닉네임 중복확인 API 호출 필요 (type을 통해 구분)
-    console.log("클릭", type);
+  const fieldValue = watch(type);
+  const isValid = !!fieldValue && !errors[type];
+  const { mutate, isPending, isSuccess, isError, error, data } =
+    useCheckDuplicate();
+
+  const handleDuplicateClick = () => {
+    mutate({ type, value: fieldValue });
   };
+
+  const getHelperText = () => {
+    switch (true) {
+      case !!errors[type]:
+        return { status: "error" as const, message: errors[type].message as string };
+      case isError:
+        return { status: "error" as const, message: error.message };
+      case isSuccess && !!data:
+        return {
+          status: data.available ? ("success" as const) : ("error" as const),
+          message: data.message,
+        };
+      default:
+        return null;
+    }
+  };
+
+  const helperText = getHelperText();
 
   return (
     <section>
@@ -29,18 +58,26 @@ export default function DuplicatedCheckField({
       </label>
       <div className="flex gap-2">
         <InputField
-          {...register(type)}
+          {...register(type, { required: true })}
           id={id}
           placeholder={placeholder}
-          className="w-82"
+          className={cn("w-82", errors[type] && "border border-negative")}
         />
         <Button
           variant="Secondary"
-          value="중복 확인"
+          value={isPending ? "확인 중" : "중복 확인"}
           className="w-21 h-11 text-body-sm"
-          onClick={() => handleDuplicateClick(type)}
+          disabled={!isValid || isPending}
+          onClick={handleDuplicateClick}
         />
       </div>
+      {helperText && (
+        <HelperText
+          status={helperText.status}
+          message={helperText.message}
+          className="mt-2"
+        />
+      )}
     </section>
   );
 }

--- a/components/auth/signup-form/duplicated-check-field/index.tsx
+++ b/components/auth/signup-form/duplicated-check-field/index.tsx
@@ -21,25 +21,40 @@ export default function DuplicatedCheckField({
   const {
     register,
     watch,
+    setValue,
     formState: { errors },
   } = useFormContext();
 
   const fieldValue = watch(type);
   const isValid = !!fieldValue && !errors[type];
-  const { mutate, isPending, isSuccess, isError, error, data } =
+  const { mutate, isPending, isSuccess, isError, error, data, variables } =
     useCheckDuplicate();
 
+  // 마지막으로 검사한 값과 현재 입력값이 다르면 이전 결과는 무효 처리한다.
+  const isResultStale = variables?.value !== fieldValue;
+
   const handleDuplicateClick = () => {
-    mutate({ type, value: fieldValue });
+    mutate(
+      { type, value: fieldValue },
+      {
+        // 중복확인에 성공(사용 가능)한 값만 폼에 기록해 제출 게이트와 연결한다.
+        onSuccess: (res) => {
+          if (res.available) setValue(`${type}Checked`, fieldValue);
+        },
+      },
+    );
   };
 
   const getHelperText = () => {
     switch (true) {
       case !!errors[type]:
-        return { status: "error" as const, message: errors[type].message as string };
-      case isError:
+        return {
+          status: "error" as const,
+          message: errors[type].message as string,
+        };
+      case !isResultStale && isError:
         return { status: "error" as const, message: error.message };
-      case isSuccess && !!data:
+      case !isResultStale && isSuccess && !!data:
         return {
           status: data.available ? ("success" as const) : ("error" as const),
           message: data.message,

--- a/components/auth/signup-form/index.tsx
+++ b/components/auth/signup-form/index.tsx
@@ -1,22 +1,37 @@
 "use client";
 
 import TermsAgreement from "@/components/auth/signup-form/terms-agreement";
+import HelperText from "@/components/common/helper-text";
 import InputField from "@/components/common/input-field";
+import { useSignup } from "@/hooks/queries/use-signup";
+import { SignupFormData, signupSchema } from "@/schemas/signup";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { FormProvider, useForm } from "react-hook-form";
 import DuplicatedCheckField from "./duplicated-check-field";
 import SignupFooter from "./signup-footer";
 
 export default function SignupForm() {
-  //   const {
-  //     register,
-  //     handleSubmit,
-  //     formState: { errors, isValid },
-  //   } = useForm();
+  const methods = useForm<SignupFormData>({
+    resolver: zodResolver(signupSchema),
+    mode: "onChange",
+    defaultValues: {
+      email: "",
+      nickname: "",
+      password: "",
+      confirmPassword: "",
+      termsAgreed: false,
+    },
+  });
 
-  const methods = useForm();
+  const { mutate: signupMutate } = useSignup();
 
-  const handleClickSubmit = (data: unknown) => {
-    // TODO: 회원가입 API 연동
+  const handleClickSubmit = (data: SignupFormData) => {
+    signupMutate({
+      email: data.email,
+      nickname: data.nickname,
+      password: data.password,
+      confirmPassword: data.confirmPassword,
+    });
   };
 
   return (
@@ -47,7 +62,17 @@ export default function SignupForm() {
               label="비밀번호"
               type="password"
               placeholder="비밀번호를 입력해 주세요."
+              className={
+                methods.formState.errors.password && "border border-negative"
+              }
             />
+            {methods.formState.errors.password && (
+              <HelperText
+                status="error"
+                message={methods.formState.errors.password.message as string}
+                className="mt-2"
+              />
+            )}
           </section>
           <section>
             <InputField
@@ -55,7 +80,20 @@ export default function SignupForm() {
               label="비밀번호 확인"
               type="password"
               placeholder="비밀번호를 다시 입력해 주세요."
+              className={
+                methods.formState.errors.confirmPassword &&
+                "border border-negative"
+              }
             />
+            {methods.formState.errors.confirmPassword && (
+              <HelperText
+                status="error"
+                message={
+                  methods.formState.errors.confirmPassword.message as string
+                }
+                className="mt-2"
+              />
+            )}
           </section>
           <TermsAgreement />
         </div>

--- a/components/auth/signup-form/index.tsx
+++ b/components/auth/signup-form/index.tsx
@@ -16,14 +16,16 @@ export default function SignupForm() {
     mode: "onChange",
     defaultValues: {
       email: "",
+      emailChecked: "",
       nickname: "",
+      nicknameChecked: "",
       password: "",
       confirmPassword: "",
       termsAgreed: false,
     },
   });
 
-  const { mutate: signupMutate } = useSignup();
+  const { mutate: signupMutate, isPending } = useSignup();
 
   const handleClickSubmit = (data: SignupFormData) => {
     signupMutate({
@@ -98,7 +100,7 @@ export default function SignupForm() {
           <TermsAgreement />
         </div>
         <div>
-          <SignupFooter />
+          <SignupFooter isPending={isPending} />
         </div>
       </form>
     </FormProvider>

--- a/components/auth/signup-form/signup-footer/index.tsx
+++ b/components/auth/signup-form/signup-footer/index.tsx
@@ -1,7 +1,12 @@
 import Button from "@/components/common/button";
 import Link from "next/link";
+import { useFormContext } from "react-hook-form";
 
 export default function SignupFooter() {
+  const {
+    formState: { isValid },
+  } = useFormContext();
+
   return (
     <section>
       <Button
@@ -9,6 +14,7 @@ export default function SignupFooter() {
         variant="Primary"
         value="회원가입"
         className="w-full"
+        disabled={!isValid}
       />
       <div className="flex justify-center gap-3 mt-6">
         <span className="text-body font-regular text-primary">

--- a/components/auth/signup-form/signup-footer/index.tsx
+++ b/components/auth/signup-form/signup-footer/index.tsx
@@ -1,11 +1,31 @@
 import Button from "@/components/common/button";
+import { PATH } from "@/constants/path";
 import Link from "next/link";
 import { useFormContext } from "react-hook-form";
 
-export default function SignupFooter() {
+interface SignupFooterProps {
+  isPending: boolean;
+}
+
+export default function SignupFooter({ isPending }: SignupFooterProps) {
   const {
     formState: { isValid },
+    watch,
   } = useFormContext();
+
+  const [email, emailChecked, nickname, nicknameChecked] = watch([
+    "email",
+    "emailChecked",
+    "nickname",
+    "nicknameChecked",
+  ]);
+
+  // 현재 입력값이 중복확인에 통과한 값과 일치할 때만 제출을 허용한다.
+  const isDuplicateChecked =
+    !!email &&
+    email === emailChecked &&
+    !!nickname &&
+    nickname === nicknameChecked;
 
   return (
     <section>
@@ -14,13 +34,13 @@ export default function SignupFooter() {
         variant="Primary"
         value="회원가입"
         className="w-full"
-        disabled={!isValid}
+        disabled={!isValid || !isDuplicateChecked || isPending}
       />
       <div className="flex justify-center gap-3 mt-6">
         <span className="text-body font-regular text-primary">
           회원이신가요?
         </span>
-        <Link href="/login" className="text-body font-bold text-primary">
+        <Link href={PATH.LOGIN} className="text-body font-bold text-primary">
           로그인 바로가기
         </Link>
       </div>

--- a/components/auth/signup-form/terms-agreement/index.tsx
+++ b/components/auth/signup-form/terms-agreement/index.tsx
@@ -3,7 +3,10 @@ import { TERMS_ARTICLES } from "@/constants";
 import { useFormContext } from "react-hook-form";
 
 export default function TermsAgreement() {
-  const { register } = useFormContext();
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext();
 
   return (
     <section>
@@ -13,7 +16,11 @@ export default function TermsAgreement() {
           <label htmlFor="auth-agree" className="text-body-sm text-primary-30">
             동의함
           </label>
-          <Checkbox id="auth-agree" {...register("termsAgreed")} />
+          <Checkbox
+            id="auth-agree"
+            {...register("termsAgreed", { required: true })}
+            className={errors.termsAgreed && "border border-negative"}
+          />
         </div>
       </div>
       <div className="w-full h-27.5 px-4 py-3 rounded-[5px] overflow-auto bg-gray-50 text-caption text-gray-600">

--- a/components/common/modal/alert-modal/index.tsx
+++ b/components/common/modal/alert-modal/index.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Button from "@/components/common/button";
+import { useModalStore } from "@/store/use-modal-store";
+
+interface AlertModalProps {
+  title: string;
+  description?: string;
+  onConfirm?: () => void;
+}
+
+export default function AlertModal({ title, description, onConfirm }: AlertModalProps) {
+  const close = useModalStore((state) => state.close);
+
+  const handleConfirm = () => {
+    onConfirm?.();
+    close();
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="font-semibold text-gray-800 text-title">{title}</h2>
+        {description && (
+          <p className="text-body text-gray-600 whitespace-pre-line">{description}</p>
+        )}
+      </div>
+      <Button variant="Primary" value="확인" onClick={handleConfirm} className="self-end" />
+    </div>
+  );
+}

--- a/components/common/modal/index.tsx
+++ b/components/common/modal/index.tsx
@@ -1,32 +1,28 @@
 "use client";
 
 import { useModalStore } from "@/store/use-modal-store";
-import { cn } from "@/utils/cn";
 import { AnimatePresence, motion } from "motion/react";
-import { type ReactNode, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 
-interface ModalProps {
-  className?: string;
-  children?: ReactNode;
-}
-
 const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
 
-export default function Modal({ className, children }: ModalProps) {
-  const { isOpen, close } = useModalStore();
+export default function Modal() {
+  const { isOpen, content, close } = useModalStore();
 
   const mounted = useSyncExternalStore(
     subscribe,
-    () => true,
-    () => false,
+    getSnapshot,
+    getServerSnapshot,
   );
 
   if (!mounted) return null;
 
   return createPortal(
     <AnimatePresence>
-      {isOpen && (
+      {isOpen && content && (
         <motion.div
           className="fixed inset-0 z-50 flex items-center justify-center bg-dim-50"
           initial={{ opacity: 0 }}
@@ -38,17 +34,14 @@ export default function Modal({ className, children }: ModalProps) {
           aria-modal="true"
         >
           <motion.div
-            className={cn(
-              "bg-white rounded-md w-full max-w-115 px-2 py-4",
-              className,
-            )}
+            className="bg-white rounded-md w-fit px-2 py-4"
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.95 }}
             transition={{ duration: 0.2 }}
             onClick={(e) => e.stopPropagation()}
           >
-            {children}
+            {content}
           </motion.div>
         </motion.div>
       )}

--- a/components/common/modal/modal.stories.tsx
+++ b/components/common/modal/modal.stories.tsx
@@ -20,40 +20,40 @@ const onConfirm = fn();
 
 export const Default: Story = {
   render: () => {
-    const { open, close, type } = useModalStore();
+    const { open, close } = useModalStore();
 
     return (
       <>
         <button
           className="px-4 py-2 rounded-md bg-primary text-white font-semibold cursor-pointer"
-          onClick={() => open("confirm")}
+          onClick={() =>
+            open(
+              <div className="flex flex-col gap-4">
+                <p className="text-body text-gray-600">정말 삭제하시겠습니까?</p>
+                <div className="flex gap-2">
+                  <button
+                    className="flex-1 h-12 rounded-[5px] bg-gray-100 text-gray-600 font-semibold cursor-pointer"
+                    onClick={close}
+                  >
+                    취소
+                  </button>
+                  <button
+                    className="flex-1 h-12 rounded-[5px] bg-primary text-white font-semibold cursor-pointer"
+                    onClick={async () => {
+                      await onConfirm();
+                      close();
+                    }}
+                  >
+                    확인
+                  </button>
+                </div>
+              </div>,
+            )
+          }
         >
           모달 열기
         </button>
-        <Modal>
-          {type === "confirm" && (
-            <div className="flex flex-col gap-4">
-              <p className="text-body text-gray-600">정말 삭제하시겠습니까?</p>
-              <div className="flex gap-2">
-                <button
-                  className="flex-1 h-12 rounded-[5px] bg-gray-100 text-gray-600 font-semibold cursor-pointer"
-                  onClick={close}
-                >
-                  취소
-                </button>
-                <button
-                  className="flex-1 h-12 rounded-[5px] bg-primary text-white font-semibold cursor-pointer"
-                  onClick={async () => {
-                    await onConfirm();
-                    close();
-                  }}
-                >
-                  확인
-                </button>
-              </div>
-            </div>
-          )}
-        </Modal>
+        <Modal />
       </>
     );
   },

--- a/components/providers/auth-provider.tsx
+++ b/components/providers/auth-provider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { refreshAccessToken } from "@/apis/auth";
+import { useEffect, useRef } from "react";
+
+// 새로고침 시 메모리의 accessToken은 사라진다. 마운트 시 1회 silent refresh를 호출해
+// HttpOnly refreshToken 쿠키가 유효하면 accessToken을 복구한다(없으면 무시).
+export default function AuthProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const bootstrapped = useRef(false);
+
+  useEffect(() => {
+    if (bootstrapped.current) return;
+    bootstrapped.current = true;
+    refreshAccessToken();
+  }, []);
+
+  return <>{children}</>;
+}

--- a/constants/endpoints.ts
+++ b/constants/endpoints.ts
@@ -1,0 +1,6 @@
+export const ENDPOINTS = {
+  SIGNUP: "signup",
+  LOGIN: "auth/login",
+  LOGOUT: "auth/logout",
+  REFRESH: "auth/refresh",
+} as const;

--- a/constants/path.ts
+++ b/constants/path.ts
@@ -1,0 +1,6 @@
+export const PATH = {
+  HOME: "/",
+  LOGIN: "/login",
+  SIGNUP: "/signup",
+  PROFILE: "/profile",
+} as const;

--- a/hooks/queries/use-check-duplicate.ts
+++ b/hooks/queries/use-check-duplicate.ts
@@ -1,0 +1,24 @@
+import { checkDuplicate } from "@/apis/auth";
+import { useMutation } from "@tanstack/react-query";
+import { HTTPError } from "ky";
+
+interface CheckDuplicateParams {
+  type: string;
+  value: string;
+}
+
+export const useCheckDuplicate = () => {
+  return useMutation({
+    mutationFn: async ({ type, value }: CheckDuplicateParams) => {
+      try {
+        return await checkDuplicate(type, value);
+      } catch (error) {
+        if (error instanceof HTTPError) {
+          const body = await error.response.json();
+          throw new Error(body.error?.message ?? "요청에 실패했습니다.");
+        }
+        throw error;
+      }
+    },
+  });
+};

--- a/hooks/queries/use-login.ts
+++ b/hooks/queries/use-login.ts
@@ -1,0 +1,62 @@
+import { login } from "@/apis/auth";
+import AlertModal from "@/components/common/modal/alert-modal";
+import { PATH } from "@/constants/path";
+import { useAuthStore } from "@/store/use-auth-store";
+import { useModalStore } from "@/store/use-modal-store";
+import { LoginRequest } from "@/types/request";
+import { useMutation } from "@tanstack/react-query";
+import { HTTPError } from "ky";
+import { useRouter } from "next/navigation";
+import { createElement } from "react";
+
+export const useLogin = () => {
+  const setAuth = useAuthStore((state) => state.setAuth);
+  const open = useModalStore((state) => state.open);
+
+  const router = useRouter();
+  const { mutate, isPending, isError } = useMutation({
+    mutationFn: async (data: LoginRequest) => {
+      return await login(data);
+    },
+    onSuccess: (res) => {
+      const authData = {
+        accessToken: res.accessToken,
+        refreshToken: res.refreshToken,
+        isFirstLogin: res.isFirstLogin,
+        isDuplicateLogin: res.isDuplicateLogin,
+      };
+
+      const nextPath = res.isFirstLogin ? PATH.PROFILE : PATH.HOME;
+
+      // TODO: 중복 로그인 처리 로직 필요
+      if (res.isDuplicateLogin) {
+        open(
+          createElement(AlertModal, {
+            title: "중복 로그인이 불가능합니다.",
+            description:
+              "다른 기기에 중복 로그인 된 상태입니다. [확인] 버튼을 누르면 다른 기기에서 강제 로그아웃되며, \n진행중이던 타이머가 있으면 기록이 자동 삭제됩니다.",
+            onConfirm: () => {
+              // 사용자가 강제 로그아웃에 동의한 뒤에 인증 상태를 저장한다.
+              setAuth(authData);
+              router.push(PATH.HOME);
+            },
+          }),
+        );
+      } else {
+        setAuth(authData);
+        router.push(nextPath);
+      }
+    },
+    onError: (error) => {
+      if (error instanceof HTTPError && error.response.status === 400) {
+        open(
+          createElement(AlertModal, {
+            title: "로그인 정보를 다시 확인해 주세요",
+          }),
+        );
+      }
+    },
+  });
+
+  return { mutate, isPending, isError };
+};

--- a/hooks/queries/use-login.ts
+++ b/hooks/queries/use-login.ts
@@ -21,14 +21,12 @@ export const useLogin = () => {
     onSuccess: (res) => {
       const authData = {
         accessToken: res.accessToken,
-        refreshToken: res.refreshToken,
         isFirstLogin: res.isFirstLogin,
         isDuplicateLogin: res.isDuplicateLogin,
       };
 
       const nextPath = res.isFirstLogin ? PATH.PROFILE : PATH.HOME;
 
-      // TODO: 중복 로그인 처리 로직 필요
       if (res.isDuplicateLogin) {
         open(
           createElement(AlertModal, {
@@ -36,7 +34,6 @@ export const useLogin = () => {
             description:
               "다른 기기에 중복 로그인 된 상태입니다. [확인] 버튼을 누르면 다른 기기에서 강제 로그아웃되며, \n진행중이던 타이머가 있으면 기록이 자동 삭제됩니다.",
             onConfirm: () => {
-              // 사용자가 강제 로그아웃에 동의한 뒤에 인증 상태를 저장한다.
               setAuth(authData);
               router.push(PATH.HOME);
             },

--- a/hooks/queries/use-logout.ts
+++ b/hooks/queries/use-logout.ts
@@ -10,9 +10,9 @@ export const useLogout = () => {
       return await logout();
     },
     onSettled: () => {
+      // 서버 응답 성공/실패와 무관하게 로컬 세션은 항상 정리한다.
       setAuth({
         accessToken: "",
-        refreshToken: "",
         isFirstLogin: false,
         isDuplicateLogin: false,
       });

--- a/hooks/queries/use-logout.ts
+++ b/hooks/queries/use-logout.ts
@@ -9,7 +9,7 @@ export const useLogout = () => {
     mutationFn: async () => {
       return await logout();
     },
-    onSuccess: () => {
+    onSettled: () => {
       setAuth({
         accessToken: "",
         refreshToken: "",

--- a/hooks/queries/use-logout.ts
+++ b/hooks/queries/use-logout.ts
@@ -1,0 +1,26 @@
+import { logout } from "@/apis/auth";
+import { useAuthStore } from "@/store/use-auth-store";
+import { useMutation } from "@tanstack/react-query";
+
+export const useLogout = () => {
+  const setAuth = useAuthStore((state) => state.setAuth);
+
+  const { mutate } = useMutation({
+    mutationFn: async () => {
+      return await logout();
+    },
+    onSuccess: () => {
+      setAuth({
+        accessToken: "",
+        refreshToken: "",
+        isFirstLogin: false,
+        isDuplicateLogin: false,
+      });
+    },
+    onError: (error) => {
+      console.error("Logout failed:", error);
+    },
+  });
+
+  return { mutate };
+};

--- a/hooks/queries/use-signup.ts
+++ b/hooks/queries/use-signup.ts
@@ -10,7 +10,7 @@ import { createElement } from "react";
 
 export const useSignup = () => {
   const router = useRouter();
-  const { mutate } = useMutation({
+  const { mutate, isPending } = useMutation({
     mutationFn: async (data: SignupRequest) => {
       return await signup(data);
     },
@@ -28,5 +28,5 @@ export const useSignup = () => {
     },
   });
 
-  return { mutate };
+  return { mutate, isPending };
 };

--- a/hooks/queries/use-signup.ts
+++ b/hooks/queries/use-signup.ts
@@ -1,0 +1,32 @@
+import { signup } from "@/apis/auth";
+import AlertModal from "@/components/common/modal/alert-modal";
+import { PATH } from "@/constants/path";
+import { useModalStore } from "@/store/use-modal-store";
+import { SignupRequest } from "@/types/request";
+import { useMutation } from "@tanstack/react-query";
+import { HTTPError } from "ky";
+import { useRouter } from "next/navigation";
+import { createElement } from "react";
+
+export const useSignup = () => {
+  const router = useRouter();
+  const { mutate } = useMutation({
+    mutationFn: async (data: SignupRequest) => {
+      return await signup(data);
+    },
+    onSuccess: () => {
+      router.replace(PATH.LOGIN);
+    },
+    onError: (error) => {
+      if (error instanceof HTTPError && error.response.status === 400) {
+        useModalStore
+          .getState()
+          .open(
+            createElement(AlertModal, { title: "회원가입에 실패했습니다" }),
+          );
+      }
+    },
+  });
+
+  return { mutate };
+};

--- a/schemas/login.ts
+++ b/schemas/login.ts
@@ -1,0 +1,18 @@
+import z from "zod";
+
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, "이메일을 입력해 주세요.")
+    .email("이메일 형식으로 작성해 주세요."),
+  password: z
+    .string()
+    .min(1, "비밀번호를 입력해 주세요.")
+    .min(8, "비밀번호는 8자 이상, 영문과 숫자 조합이어야 합니다.")
+    .regex(
+      /^(?=.*[a-zA-Z])(?=.*\d)/,
+      "비밀번호는 8자 이상, 영문과 숫자 조합이어야 합니다.",
+    ),
+});
+
+export type LoginFormData = z.infer<typeof loginSchema>;

--- a/schemas/signup.ts
+++ b/schemas/signup.ts
@@ -6,7 +6,9 @@ export const signupSchema = z
       .string()
       .min(1, "이메일을 입력해 주세요.")
       .email("이메일 형식으로 작성해 주세요."),
+    emailChecked: z.string(),
     nickname: z.string().min(1, "닉네임을 입력해 주세요."),
+    nicknameChecked: z.string(),
     password: z
       .string()
       .min(1, "비밀번호를 입력해 주세요.")

--- a/schemas/signup.ts
+++ b/schemas/signup.ts
@@ -1,0 +1,26 @@
+import z from "zod";
+
+export const signupSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, "이메일을 입력해 주세요.")
+      .email("이메일 형식으로 작성해 주세요."),
+    nickname: z.string().min(1, "닉네임을 입력해 주세요."),
+    password: z
+      .string()
+      .min(1, "비밀번호를 입력해 주세요.")
+      .min(8, "비밀번호는 8자 이상, 영문과 숫자 조합이어야 합니다.")
+      .regex(
+        /^(?=.*[a-zA-Z])(?=.*\d)/,
+        "비밀번호는 8자 이상, 영문과 숫자 조합이어야 합니다.",
+      ),
+    confirmPassword: z.string().min(1, "비밀번호가 일치하지 않습니다."),
+    termsAgreed: z.boolean().refine((val) => val === true),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "비밀번호가 일치하지 않습니다.",
+    path: ["confirmPassword"],
+  });
+
+export type SignupFormData = z.infer<typeof signupSchema>;

--- a/store/use-auth-store.ts
+++ b/store/use-auth-store.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AuthState {
+  accessToken: string;
+  refreshToken: string;
+  isFirstLogin: boolean;
+  isDuplicateLogin: boolean;
+  setAuth: (auth: Omit<AuthState, "setAuth">) => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: "",
+      refreshToken: "",
+      isFirstLogin: false,
+      isDuplicateLogin: false,
+      setAuth: (auth) => set(auth),
+    }),
+    {
+      name: "auth-storage",
+    },
+  ),
+);

--- a/store/use-auth-store.ts
+++ b/store/use-auth-store.ts
@@ -1,25 +1,17 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 
 interface AuthState {
   accessToken: string;
-  refreshToken: string;
   isFirstLogin: boolean;
   isDuplicateLogin: boolean;
   setAuth: (auth: Omit<AuthState, "setAuth">) => void;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      accessToken: "",
-      refreshToken: "",
-      isFirstLogin: false,
-      isDuplicateLogin: false,
-      setAuth: (auth) => set(auth),
-    }),
-    {
-      name: "auth-storage",
-    },
-  ),
-);
+// refreshToken은 Next.js BFF가 HttpOnly 쿠키로 관리한다.
+// 클라이언트는 accessToken만 메모리에 보관한다.
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: "",
+  isFirstLogin: false,
+  isDuplicateLogin: false,
+  setAuth: (auth) => set(auth),
+}));

--- a/store/use-modal-store.ts
+++ b/store/use-modal-store.ts
@@ -1,17 +1,16 @@
+import type { ReactNode } from "react";
 import { create } from "zustand";
 
 interface ModalState {
   isOpen: boolean;
-  type: string | null;
-  payload: Record<string, unknown> | null;
-  open: (type: string, payload?: Record<string, unknown>) => void;
+  content: ReactNode | null;
+  open: (content: ReactNode) => void;
   close: () => void;
 }
 
 export const useModalStore = create<ModalState>((set) => ({
   isOpen: false,
-  type: null,
-  payload: null,
-  open: (type, payload) => set({ isOpen: true, type, payload: payload ?? null }),
-  close: () => set({ isOpen: false, type: null, payload: null }),
+  content: null,
+  open: (content) => set({ isOpen: true, content }),
+  close: () => set({ isOpen: false, content: null }),
 }));

--- a/types/request.ts
+++ b/types/request.ts
@@ -1,0 +1,15 @@
+export interface SignupRequest {
+  email: string;
+  nickname: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RefreshTokenRequest {
+  refreshToken: string;
+}

--- a/types/response.ts
+++ b/types/response.ts
@@ -9,13 +9,19 @@ export interface SignupResponse {
   message: string;
 }
 
+// 브라우저로 내려오는 로그인 응답. refreshToken은 BFF가 HttpOnly 쿠키로
+// 처리하므로 클라이언트 응답 바디에는 포함되지 않는다.
 export interface LoginResponse {
   success: boolean;
   message: string;
   accessToken: string;
-  refreshToken: string;
   isFirstLogin: boolean;
   isDuplicateLogin: boolean;
+}
+
+// 백엔드 원본 로그인 응답(서버 측 Route Handler에서만 사용). refreshToken 포함.
+export interface BackendLoginResponse extends LoginResponse {
+  refreshToken: string;
 }
 
 export interface LogoutResponse {

--- a/types/response.ts
+++ b/types/response.ts
@@ -1,0 +1,29 @@
+export interface CheckDuplicateResponse {
+  success: boolean;
+  available: boolean;
+  message: string;
+}
+
+export interface SignupResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface LoginResponse {
+  success: boolean;
+  message: string;
+  accessToken: string;
+  refreshToken: string;
+  isFirstLogin: boolean;
+  isDuplicateLogin: boolean;
+}
+
+export interface LogoutResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface RefreshTokenResponse {
+  success: boolean;
+  accessToken: string;
+}


### PR DESCRIPTION
## 📌관련 이슈

> #15 

## 📝작업 내용
- 로그인 및 회원가입 api 연동 및 tanstack-query 관련 hook 구현
- api 요청 및 응답 관련 타입 추가
- endpoints 및 path 경로 상수로 관리
- api-client에서 요청 전 토큰 주입과 401 인증 에러 발생시 응답 처리

## 💻 스크린샷 (선택)
<img width="758" height="449" alt="image" src="https://github.com/user-attachments/assets/d860d25f-2c7f-4fb7-831b-514fb5f99c45" />

## 💬코멘트 (선택)
- 중복 로그인 처리 로직은 다음 위의 스크린샷과 같은 로직으로 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 로그인/회원가입 흐름 전면 추가(검증 스키마·폼·훅·API 래퍼 포함), 이메일·닉네임 중복확인 UI/훅
  * 클라이언트 인증 저장소 및 앱 초기 복구(자동 액세스 토큰 갱신)
  * 안전한 인증 갱신 및 401 발생 시 단일 재시도 로직
  * 모달 구조 개선 및 AlertModal 추가, 경로 상수(PATH/ENDPOINTS) 도입

* **Bug Fixes**
  * 제출 버튼 비활성화·에러 표시 개선(유효성·중복검사 반영)
  * 중복 로그인/로그인 실패 안내 흐름 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->