### PR TITLE
Feat/profile api/#18

### DIFF
--- a/apis/profile.ts
+++ b/apis/profile.ts
@@ -1,0 +1,30 @@
+import { ENDPOINTS } from "@/constants/endpoints";
+import { CreateProfileRequest, PresignedUrlRequest } from "@/types/request";
+import {
+  CreateProfileResponse,
+  PresignedUrlResponse,
+} from "@/types/response";
+import { httpClient } from "./api-client";
+
+export const getPresignedUrl = (data: PresignedUrlRequest) =>
+  httpClient.post<PresignedUrlResponse>(ENDPOINTS.PRESIGNED_URL, data);
+
+// presignedUrl로 스토리지에 직접 PUT. prefixUrl·인증 헤더가 붙는 httpClient(ky)를
+// 쓰면 안 되므로 순수 fetch를 사용한다.
+export const uploadFileToPresignedUrl = async (
+  presignedUrl: string,
+  file: File,
+) => {
+  const res = await fetch(presignedUrl, {
+    method: "PUT",
+    headers: { "Content-Type": file.type },
+    body: file,
+  });
+
+  if (!res.ok) {
+    throw new Error("이미지 업로드에 실패했습니다.");
+  }
+};
+
+export const createProfile = (data: CreateProfileRequest) =>
+  httpClient.post<CreateProfileResponse>(ENDPOINTS.PROFILE, data);

--- a/apis/tech-stack.ts
+++ b/apis/tech-stack.ts
@@ -1,0 +1,15 @@
+import { ENDPOINTS } from "@/constants/endpoints";
+import { CreateTechStackRequest } from "@/types/request";
+import {
+  CreateTechStackResponse,
+  TechStacksResponse,
+} from "@/types/response";
+import { httpClient } from "./api-client";
+
+export const getTechStacks = (keyword: string) =>
+  httpClient.get<TechStacksResponse>(
+    `${ENDPOINTS.TECH_STACKS}?keyword=${encodeURIComponent(keyword)}`,
+  );
+
+export const createTechStack = (data: CreateTechStackRequest) =>
+  httpClient.post<CreateTechStackResponse>(ENDPOINTS.TECH_STACKS, data);

--- a/components/auth/login-form/index.tsx
+++ b/components/auth/login-form/index.tsx
@@ -24,10 +24,10 @@ export default function LoginForm() {
     },
   });
 
-  const { mutate: loginMutate, isPending } = useLogin();
+  const { login, isPending } = useLogin();
 
   const handleClickSubmit = (data: LoginFormData) => {
-    loginMutate(data);
+    login(data);
   };
 
   return (
@@ -72,6 +72,7 @@ export default function LoginForm() {
             value="로그인"
             variant="Primary"
             type="submit"
+            className="w-full"
             disabled={!isValid || isPending}
           />
           <Link

--- a/components/auth/signup-form/duplicated-check-field/index.tsx
+++ b/components/auth/signup-form/duplicated-check-field/index.tsx
@@ -27,14 +27,21 @@ export default function DuplicatedCheckField({
 
   const fieldValue = watch(type);
   const isValid = !!fieldValue && !errors[type];
-  const { mutate, isPending, isSuccess, isError, error, data, variables } =
-    useCheckDuplicate();
+  const {
+    checkDuplicate,
+    isPending,
+    isSuccess,
+    isError,
+    error,
+    data,
+    variables,
+  } = useCheckDuplicate();
 
   // 마지막으로 검사한 값과 현재 입력값이 다르면 이전 결과는 무효 처리한다.
   const isResultStale = variables?.value !== fieldValue;
 
   const handleDuplicateClick = () => {
-    mutate(
+    checkDuplicate(
       { type, value: fieldValue },
       {
         // 중복확인에 성공(사용 가능)한 값만 폼에 기록해 제출 게이트와 연결한다.

--- a/components/auth/signup-form/index.tsx
+++ b/components/auth/signup-form/index.tsx
@@ -25,10 +25,10 @@ export default function SignupForm() {
     },
   });
 
-  const { mutate: signupMutate, isPending } = useSignup();
+  const { signup, isPending } = useSignup();
 
   const handleClickSubmit = (data: SignupFormData) => {
-    signupMutate({
+    signup({
       email: data.email,
       nickname: data.nickname,
       password: data.password,

--- a/components/common/auto-complete/highlighted-name.tsx
+++ b/components/common/auto-complete/highlighted-name.tsx
@@ -1,0 +1,31 @@
+/**
+ * 검색어 하이라이트 컴포넌트
+ * - 기술스택 이름(name) 중 검색어(query)와 일치하는 부분을 text-gray-800으로 강조
+ * - 나머지 부분은 text-gray-500으로 표시
+ * ex) query="AA", name="AAATHCHYYU" → "AA"(gray-800) + "ATHCHYYU"(gray-500)
+ */
+export default function HighlightedName({
+  name,
+  query,
+}: {
+  name: string;
+  query: string;
+}) {
+  if (!query) return <span className="text-gray-500">{name}</span>;
+
+  const index = name.toLowerCase().indexOf(query.toLowerCase());
+  if (index === -1) return <span className="text-gray-500">{name}</span>;
+
+  // 검색어 기준으로 앞(before) / 일치(match) / 뒤(after) 세 부분으로 분리
+  const before = name.slice(0, index);
+  const match = name.slice(index, index + query.length);
+  const after = name.slice(index + query.length);
+
+  return (
+    <span className="text-gray-500 font-regular">
+      {before}
+      <span className="text-gray-800 font-semibold">{match}</span>
+      {after}
+    </span>
+  );
+}

--- a/components/common/auto-complete/index.tsx
+++ b/components/common/auto-complete/index.tsx
@@ -2,12 +2,11 @@
 
 import AddIcon from "@/assets/icons/plus.svg";
 import InputField from "@/components/common/input-field";
-import { useEffect, useRef, useState } from "react";
+import { useAutoComplete } from "@/hooks/use-auto-complete";
+import type { TechStackItem } from "@/hooks/use-auto-complete";
+import HighlightedName from "./highlighted-name";
 
-export interface TechStackItem {
-  id: number;
-  name: string;
-}
+export type { TechStackItem };
 
 interface AutoCompleteProps {
   placeholder: string;
@@ -15,130 +14,21 @@ interface AutoCompleteProps {
   onSelect?: (item: TechStackItem) => void;
 }
 
-// -------------------------------------------------------
-// [MOCK 데이터] API 연결 시 이 상수를 제거하고,
-// API 응답 데이터로 대체해야 합니다.
-// -------------------------------------------------------
-const SEARCH_LIST = [
-  {
-    id: 0,
-    name: "AAABC",
-    createdAt: "2026-04-17T10:23:20.272Z",
-    updatedAt: "2026-04-17T10:23:20.272Z",
-  },
-  {
-    id: 1,
-    name: "AABYF",
-    createdAt: "2026-04-17T10:23:20.272Z",
-    updatedAt: "2026-04-17T10:23:20.272Z",
-  },
-  {
-    id: 2,
-    name: "AACDDFG",
-    createdAt: "2026-04-17T10:23:20.272Z",
-    updatedAt: "2026-04-17T10:23:20.272Z",
-  },
-  {
-    id: 3,
-    name: "AAGHR",
-    createdAt: "2026-04-17T10:23:20.272Z",
-    updatedAt: "2026-04-17T10:23:20.272Z",
-  },
-  {
-    id: 4,
-    name: "AAATHCHYYU",
-    createdAt: "2026-04-17T10:23:20.272Z",
-    updatedAt: "2026-04-17T10:23:20.272Z",
-  },
-  {
-    id: 5,
-    name: "AAAADFSTHCHYYU",
-    createdAt: "2026-04-17T10:23:20.272Z",
-    updatedAt: "2026-04-17T10:23:20.272Z",
-  },
-];
-
-/**
- * 검색어 하이라이트 컴포넌트
- * - 기술스택 이름(name) 중 검색어(query)와 일치하는 부분을 text-gray-800으로 강조
- * - 나머지 부분은 text-gray-500으로 표시
- * ex) query="AA", name="AAATHCHYYU" → "AA"(gray-800) + "ATHCHYYU"(gray-500)
- */
-function HighlightedName({ name, query }: { name: string; query: string }) {
-  if (!query) return <span className="text-gray-500">{name}</span>;
-
-  const index = name.toLowerCase().indexOf(query.toLowerCase());
-  if (index === -1) return <span className="text-gray-500">{name}</span>;
-
-  // 검색어 기준으로 앞(before) / 일치(match) / 뒤(after) 세 부분으로 분리
-  const before = name.slice(0, index);
-  const match = name.slice(index, index + query.length);
-  const after = name.slice(index + query.length);
-
-  return (
-    <span className="text-gray-500 font-regular">
-      {before}
-      <span className="text-gray-800 font-semibold">{match}</span>
-      {after}
-    </span>
-  );
-}
-
 export default function AutoComplete({
   placeholder,
   label,
   onSelect,
 }: AutoCompleteProps) {
-  // 검색어 상태
-  const [query, setQuery] = useState("");
-  // 드롭다운 열림/닫힘 상태 — 검색어가 입력되면 true
-  const [isOpen, setIsOpen] = useState(false);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  // -------------------------------------------------------
-  // [필터링 로직] API 연결 시 이 부분을 대체해야 합니다.
-  // -------------------------------------------------------
-  const filteredList = SEARCH_LIST.filter((item) =>
-    item.name.toLowerCase().includes(query.toLowerCase()),
-  );
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  // 입력값이 변경될 때마다 검색어 업데이트 + 드롭다운 열기/닫기 제어
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const inputValue = e.target.value;
-    setQuery(inputValue);
-    setIsOpen(inputValue.length > 0);
-  };
-
-  // 리스트 항목 클릭 시 부모에게 선택된 항목 전달
-  const handleSelect = (item: TechStackItem) => {
-    onSelect?.(item);
-    setQuery("");
-    setIsOpen(false);
-  };
-
-  // "Add New Item" 클릭 시 입력값을 새 항목으로 생성하여 부모에게 전달
-  // 추후에  /api/tech-stacks 엔드포인트로 POST 요청을 보내 새 기술스택을 생성하는 로직으로 대체해야 합니다.
-  const handleAddNewItem = () => {
-    if (!query.trim()) return;
-    const newItem: TechStackItem = { id: Date.now(), name: query.trim() };
-    onSelect?.(newItem);
-    setQuery("");
-    setIsOpen(false);
-  };
+  const {
+    query,
+    isOpen,
+    containerRef,
+    techStacks,
+    handleChange,
+    handleSelect,
+    handleAddNewItem,
+    handleKeyDown,
+  } = useAutoComplete(onSelect);
 
   return (
     <div className="relative" ref={containerRef}>
@@ -148,14 +38,15 @@ export default function AutoComplete({
         placeholder={placeholder}
         value={query}
         onChange={handleChange}
+        onKeyDown={handleKeyDown}
       />
 
       {/* 검색 결과 드롭다운 — isOpen이 true일 때만 렌더링 */}
       {isOpen && (
         <ul className="absolute top-full w-full left-0 mt-2 z-10 border border-gray-300 bg-white rounded-[5px] overflow-auto max-h-40">
-          {filteredList.length > 0 ? (
+          {techStacks.length > 0 ? (
             // 검색어에 매칭되는 기술스택 리스트 렌더링
-            filteredList.map((item) => (
+            techStacks.map((item) => (
               <li
                 key={item.id}
                 className="px-3 py-4 cursor-pointer"

--- a/components/common/button/index.tsx
+++ b/components/common/button/index.tsx
@@ -8,7 +8,7 @@ interface ButtonProps extends ComponentProps<"button"> {
 }
 
 const base =
-  "w-full h-12 rounded-[5px] text-subtitle py-3 px-4 cursor-pointer font-semibold outline-none";
+  "h-12 rounded-[5px] text-subtitle py-3 px-4 cursor-pointer font-semibold outline-none";
 
 const themeVariants = {
   Primary: `${base} bg-primary text-white hover:shadow-overlay active:shadow-overlay disabled:bg-gray-400 disabled:text-gray-300 disabled:cursor-not-allowed`,

--- a/components/common/modal/alert-modal/index.tsx
+++ b/components/common/modal/alert-modal/index.tsx
@@ -25,7 +25,7 @@ export default function AlertModal({ title, description, onConfirm }: AlertModal
           <p className="text-body text-gray-600 whitespace-pre-line">{description}</p>
         )}
       </div>
-      <Button variant="Primary" value="확인" onClick={handleConfirm} className="self-end" />
+      <Button variant="Primary" value="확인" onClick={handleConfirm} className="w-full self-end" />
     </div>
   );
 }

--- a/components/common/modal/confirm-modal/index.tsx
+++ b/components/common/modal/confirm-modal/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Button from "@/components/common/button";
+import { useModalStore } from "@/store/use-modal-store";
+
+interface ConfirmModalProps {
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}
+
+export default function ConfirmModal({
+  title,
+  description,
+  confirmText = "확인",
+  cancelText = "취소",
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const close = useModalStore((state) => state.close);
+
+  const handleConfirm = () => {
+    onConfirm?.();
+    close();
+  };
+
+  const handleCancel = () => {
+    onCancel?.();
+    close();
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="font-semibold text-gray-800 text-title">{title}</h2>
+        {description && (
+          <p className="text-body text-gray-600 whitespace-pre-line">
+            {description}
+          </p>
+        )}
+      </div>
+      <div className="flex gap-4 self-end">
+        <Button variant="Tertiary" value={cancelText} onClick={handleCancel} />
+        <Button variant="Primary" value={confirmText} onClick={handleConfirm} />
+      </div>
+    </div>
+  );
+}

--- a/components/profile/profile-form/index.tsx
+++ b/components/profile/profile-form/index.tsx
@@ -7,34 +7,56 @@ import InputField from "@/components/common/input-field";
 import SelectDropdown from "@/components/common/select-dropdown";
 import ImageUpload from "@/components/profile/image-upload";
 import ProfileFormFooter from "@/components/profile/profile-form/profile-form-footer";
-import { SELECT_CAREER_OPTIONS, SELECT_PURPOSE_OPTIONS } from "@/constants";
+import {
+  CUSTOM_PURPOSE,
+  SELECT_CAREER_OPTIONS,
+  SELECT_PURPOSE_OPTIONS,
+} from "@/constants";
+import { useCreateProfile } from "@/hooks/queries/use-create-profile";
+import { useUploadImage } from "@/hooks/queries/use-upload-image";
+import { ProfileFormData, profileSchema } from "@/schemas/profile";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Controller, useForm, useWatch } from "react-hook-form";
 
 export default function ProfileForm() {
-  const { control, register, handleSubmit, setValue, getValues } = useForm({
+  const {
+    control,
+    register,
+    handleSubmit,
+    setValue,
+    getValues,
+    formState: { isValid },
+  } = useForm<ProfileFormData>({
+    resolver: zodResolver(profileSchema),
+    mode: "onChange",
     defaultValues: {
       career: "",
       purpose: "",
       customPurpose: "",
       goal: "",
-      techStacks: [] as TechStackItem[],
-      profileImage: null as File | null,
+      techStacks: [],
+      profileImage: null,
     },
   });
   const purpose = useWatch({ control, name: "purpose" });
   const techStacks = useWatch({ control, name: "techStacks" });
+  const { uploadImage, isUploading } = useUploadImage();
+  const { createProfile, isPending } = useCreateProfile();
 
-  const onSubmit = handleSubmit((data) => {
-    const submitData = {
+  const onSubmit = handleSubmit(async (data) => {
+    // 이미지가 있을 때만 presigned URL로 업로드하고, 저장용 key를 받아온다.
+    const profileImage = data.profileImage
+      ? await uploadImage(data.profileImage)
+      : "";
+
+    await createProfile({
       career: data.career,
       purpose:
-        data.purpose === "기타(직접 입력)" ? data.customPurpose : data.purpose,
+        data.purpose === CUSTOM_PURPOSE ? data.customPurpose : data.purpose,
       goal: data.goal,
       techStacks: data.techStacks.map((item) => item.name),
-      // 추후에 api연동하고 presignedURL 적용하면서 수정 예정
-      profileImage: data.profileImage?.name ?? "",
-    };
-    console.log(submitData);
+      profileImage,
+    });
   });
 
   const handleSelect = (item: TechStackItem) => {
@@ -88,7 +110,7 @@ export default function ProfileForm() {
               />
             )}
           />
-          {purpose === "기타(직접 입력)" && (
+          {purpose === CUSTOM_PURPOSE && (
             <InputField
               placeholder="공부 목적을 입력해 주세요."
               {...register("customPurpose")}
@@ -128,7 +150,7 @@ export default function ProfileForm() {
             <ImageUpload value={field.value} onChange={field.onChange} />
           )}
         />
-        <ProfileFormFooter />
+        <ProfileFormFooter disabled={!isValid || isUploading || isPending} />
       </div>
     </form>
   );

--- a/components/profile/profile-form/index.tsx
+++ b/components/profile/profile-form/index.tsx
@@ -62,7 +62,9 @@ export default function ProfileForm() {
   const handleSelect = (item: TechStackItem) => {
     const current = getValues("techStacks");
     if (current.some((v) => v.id === item.id || v.name === item.name)) return;
-    setValue("techStacks", [...current, item]);
+    // setValue는 기본적으로 재검증을 트리거하지 않으므로, isValid가 갱신되도록
+    // shouldValidate를 명시한다. (techStacks 추가/삭제만으로 제출 버튼 활성화 반영)
+    setValue("techStacks", [...current, item], { shouldValidate: true });
   };
 
   const handleDelete = (id: number) => {
@@ -70,6 +72,7 @@ export default function ProfileForm() {
     setValue(
       "techStacks",
       current.filter((item) => item.id !== id),
+      { shouldValidate: true },
     );
   };
 

--- a/components/profile/profile-form/profile-form-footer/index.tsx
+++ b/components/profile/profile-form/profile-form-footer/index.tsx
@@ -1,6 +1,35 @@
-import Button from "@/components/common/button";
+"use client";
 
-export default function ProfileFormFooter() {
+import Button from "@/components/common/button";
+import ConfirmModal from "@/components/common/modal/confirm-modal";
+import { PATH } from "@/constants/path";
+import { useModalStore } from "@/store/use-modal-store";
+import { useRouter } from "next/navigation";
+import { createElement } from "react";
+
+interface ProfileFormFooterProps {
+  disabled?: boolean;
+}
+
+export default function ProfileFormFooter({
+  disabled,
+}: ProfileFormFooterProps) {
+  const router = useRouter();
+  const open = useModalStore((state) => state.open);
+
+  const handleSkip = () => {
+    open(
+      createElement(ConfirmModal, {
+        title: "프로필 설정을 건너뛸까요?",
+        description:
+          "프로필을 설정하지 않을 경우 일부 기능 사용에 제한이 생길 수 있습니다. 그래도 프로필 설정을 건너뛰시겠습니까?",
+        cancelText: "건너뛰기",
+        confirmText: "계속 설정하기",
+        onCancel: () => router.replace(PATH.HOME),
+      }),
+    );
+  };
+
   return (
     <section>
       <Button
@@ -8,13 +37,14 @@ export default function ProfileFormFooter() {
         variant="Primary"
         value="저장하기"
         className="w-full"
+        disabled={disabled}
       />
       <div className="flex justify-center gap-3 mt-6">
         <span className="text-body font-regular text-primary">
           다음에 하시겠어요?
         </span>
         <span
-          onClick={() => console.log("클릭")}
+          onClick={handleSkip}
           className="text-body font-bold text-primary cursor-pointer"
         >
           건너뛰기

--- a/constants/endpoints.ts
+++ b/constants/endpoints.ts
@@ -3,4 +3,7 @@ export const ENDPOINTS = {
   LOGIN: "auth/login",
   LOGOUT: "auth/logout",
   REFRESH: "auth/refresh",
+  PRESIGNED_URL: "file/presigned-url",
+  PROFILE: "profile",
+  TECH_STACKS: "tech-stacks",
 } as const;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -64,10 +64,12 @@ export const SELECT_CAREER_OPTIONS: string[] = [
   "11년 이상",
 ];
 
+export const CUSTOM_PURPOSE = "기타(직접 입력)";
+
 export const SELECT_PURPOSE_OPTIONS: string[] = [
   "취업 준비",
   "이직 준비",
   "단순 개발 역량 향상",
   "회사 내 프로젝트 원활하게 수행",
-  "기타(직접 입력)",
+  CUSTOM_PURPOSE,
 ];

--- a/hooks/queries/use-check-duplicate.ts
+++ b/hooks/queries/use-check-duplicate.ts
@@ -8,7 +8,7 @@ interface CheckDuplicateParams {
 }
 
 export const useCheckDuplicate = () => {
-  return useMutation({
+  const { mutate, ...rest } = useMutation({
     mutationFn: async ({ type, value }: CheckDuplicateParams) => {
       try {
         return await checkDuplicate(type, value);
@@ -21,4 +21,6 @@ export const useCheckDuplicate = () => {
       }
     },
   });
+
+  return { checkDuplicate: mutate, ...rest };
 };

--- a/hooks/queries/use-create-profile.ts
+++ b/hooks/queries/use-create-profile.ts
@@ -1,0 +1,32 @@
+import { createProfile } from "@/apis/profile";
+import AlertModal from "@/components/common/modal/alert-modal";
+import { PATH } from "@/constants/path";
+import { useModalStore } from "@/store/use-modal-store";
+import { CreateProfileRequest } from "@/types/request";
+import { useMutation } from "@tanstack/react-query";
+import { HTTPError } from "ky";
+import { useRouter } from "next/navigation";
+import { createElement } from "react";
+
+export const useCreateProfile = () => {
+  const router = useRouter();
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: async (data: CreateProfileRequest) => {
+      return await createProfile(data);
+    },
+    onSuccess: () => {
+      router.replace(PATH.HOME);
+    },
+    onError: (error) => {
+      if (error instanceof HTTPError && error.response.status === 400) {
+        useModalStore
+          .getState()
+          .open(
+            createElement(AlertModal, { title: "프로필 설정에 실패했습니다" }),
+          );
+      }
+    },
+  });
+
+  return { createProfile: mutateAsync, isPending };
+};

--- a/hooks/queries/use-create-tech-stack.ts
+++ b/hooks/queries/use-create-tech-stack.ts
@@ -1,0 +1,19 @@
+import { createTechStack } from "@/apis/tech-stack";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export const useCreateTechStack = () => {
+  const queryClient = useQueryClient();
+  const { mutateAsync, isPending } = useMutation({
+    // 응답을 언래핑해 생성된 techStack 항목만 resolve한다.
+    mutationFn: async (name: string) => {
+      const { techStack } = await createTechStack({ name });
+      return techStack;
+    },
+    onSuccess: () => {
+      // 새로 만든 키워드가 이후 검색 결과에 반영되도록 캐시를 무효화한다.
+      queryClient.invalidateQueries({ queryKey: ["tech-stacks"] });
+    },
+  });
+
+  return { createTechStack: mutateAsync, isCreating: isPending };
+};

--- a/hooks/queries/use-login.ts
+++ b/hooks/queries/use-login.ts
@@ -55,5 +55,5 @@ export const useLogin = () => {
     },
   });
 
-  return { mutate, isPending, isError };
+  return { login: mutate, isPending, isError };
 };

--- a/hooks/queries/use-logout.ts
+++ b/hooks/queries/use-logout.ts
@@ -22,5 +22,5 @@ export const useLogout = () => {
     },
   });
 
-  return { mutate };
+  return { logout: mutate };
 };

--- a/hooks/queries/use-signup.ts
+++ b/hooks/queries/use-signup.ts
@@ -28,5 +28,5 @@ export const useSignup = () => {
     },
   });
 
-  return { mutate, isPending };
+  return { signup: mutate, isPending };
 };

--- a/hooks/queries/use-tech-stacks.ts
+++ b/hooks/queries/use-tech-stacks.ts
@@ -1,0 +1,12 @@
+import { getTechStacks } from "@/apis/tech-stack";
+import { useQuery } from "@tanstack/react-query";
+
+export const useTechStacks = (keyword: string) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ["tech-stacks", keyword],
+    queryFn: () => getTechStacks(keyword),
+    enabled: keyword.length > 0, // 빈 검색어일 땐 요청을 보내지 않는다.
+  });
+
+  return { techStacks: data?.results ?? [], isLoading };
+};

--- a/hooks/queries/use-upload-image.ts
+++ b/hooks/queries/use-upload-image.ts
@@ -1,0 +1,18 @@
+import { getPresignedUrl, uploadFileToPresignedUrl } from "@/apis/profile";
+import { useMutation } from "@tanstack/react-query";
+
+// presigned URL 발급 → 스토리지에 직접 업로드 → 저장용 key 반환
+export const useUploadImage = () => {
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: async (file: File): Promise<string> => {
+      const { presignedUrl, key } = await getPresignedUrl({
+        fileName: file.name,
+        contentType: file.type,
+      });
+      await uploadFileToPresignedUrl(presignedUrl, file);
+      return key;
+    },
+  });
+
+  return { uploadImage: mutateAsync, isUploading: isPending };
+};

--- a/hooks/use-auto-complete.ts
+++ b/hooks/use-auto-complete.ts
@@ -1,0 +1,86 @@
+import { useCreateTechStack } from "@/hooks/queries/use-create-tech-stack";
+import { useTechStacks } from "@/hooks/queries/use-tech-stacks";
+import { useDebounce } from "@/hooks/use-debounce";
+import { useEffect, useRef, useState } from "react";
+
+export interface TechStackItem {
+  id: number;
+  name: string;
+}
+
+/**
+ * 기술스택 autocomplete의 상호작용 로직을 담당하는 훅.
+ * - 검색어 디바운스 후 GET /tech-stacks?keyword= 조회
+ * - 매칭 결과가 없을 때 POST /tech-stacks로 신규 생성
+ * - 드롭다운 열림/닫힘 및 외부 클릭 시 닫기 제어
+ */
+export function useAutoComplete(onSelect?: (item: TechStackItem) => void) {
+  // 검색어 상태
+  const [query, setQuery] = useState("");
+  // 드롭다운 열림/닫힘 상태 — 검색어가 입력되면 true
+  const [isOpen, setIsOpen] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 입력값을 디바운스해 검색어별로 GET /tech-stacks?keyword= 를 조회한다.
+  const debouncedQuery = useDebounce(query, 300);
+  const { techStacks } = useTechStacks(debouncedQuery);
+  const { createTechStack, isCreating } = useCreateTechStack();
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // 입력값이 변경될 때마다 검색어 업데이트 + 드롭다운 열기/닫기 제어
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    setQuery(inputValue);
+    setIsOpen(inputValue.length > 0);
+  };
+
+  // 리스트 항목 클릭 시 부모에게 선택된 항목 전달
+  const handleSelect = (item: TechStackItem) => {
+    onSelect?.(item);
+    setQuery("");
+    setIsOpen(false);
+  };
+
+  // "Add New Item" 클릭/Enter 시 POST /tech-stacks로 새 기술스택을 생성하고,
+  // 서버가 발급한 실제 id를 가진 항목을 부모에게 전달한다.
+  const handleAddNewItem = async () => {
+    const name = query.trim();
+    if (!name || isCreating) return;
+
+    const created = await createTechStack(name);
+    onSelect?.(created);
+    setQuery("");
+    setIsOpen(false);
+  };
+
+  // 입력값이 기존 기술스택과 매칭되지 않을 때만 Enter로 신규 생성한다.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault(); // 폼 제출 방지
+    if (techStacks.length === 0) handleAddNewItem();
+  };
+
+  return {
+    query,
+    isOpen,
+    containerRef,
+    techStacks,
+    handleChange,
+    handleSelect,
+    handleAddNewItem,
+    handleKeyDown,
+  };
+}

--- a/hooks/use-auto-complete.ts
+++ b/hooks/use-auto-complete.ts
@@ -24,7 +24,7 @@ export function useAutoComplete(onSelect?: (item: TechStackItem) => void) {
 
   // 입력값을 디바운스해 검색어별로 GET /tech-stacks?keyword= 를 조회한다.
   const debouncedQuery = useDebounce(query, 300);
-  const { techStacks } = useTechStacks(debouncedQuery);
+  const { techStacks, isLoading } = useTechStacks(debouncedQuery);
   const { createTechStack, isCreating } = useCreateTechStack();
 
   useEffect(() => {
@@ -60,17 +60,26 @@ export function useAutoComplete(onSelect?: (item: TechStackItem) => void) {
     const name = query.trim();
     if (!name || isCreating) return;
 
-    const created = await createTechStack(name);
-    onSelect?.(created);
-    setQuery("");
-    setIsOpen(false);
+    try {
+      const created = await createTechStack(name);
+      onSelect?.(created);
+      setQuery("");
+      setIsOpen(false);
+    } catch (error) {
+      // 생성 실패 시 입력값과 드롭다운을 유지해 사용자가 재시도할 수 있게 한다.
+      console.error("기술스택 생성에 실패했습니다.", error);
+    }
   };
 
-  // 입력값이 기존 기술스택과 매칭되지 않을 때만 Enter로 신규 생성한다.
+  // Enter로 신규 생성하려면 (1) 디바운스가 따라잡아 조회 결과가 현재 입력과
+  // 일치하고(debouncedQuery === query) (2) 조회가 끝났으며(!isLoading)
+  // (3) 매칭되는 기존 항목이 없어야 한다. 로딩 중 조회 결과를 신뢰해 오생성하는 것을 막는다.
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== "Enter") return;
     e.preventDefault(); // 폼 제출 방지
-    if (techStacks.length === 0) handleAddNewItem();
+
+    const isResultReady = debouncedQuery === query && !isLoading;
+    if (isResultReady && techStacks.length === 0) handleAddNewItem();
   };
 
   return {

--- a/hooks/use-debounce.ts
+++ b/hooks/use-debounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export const useDebounce = <T>(value: T, delay = 300) => {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+};

--- a/schemas/profile.ts
+++ b/schemas/profile.ts
@@ -10,10 +10,12 @@ export const profileSchema = z
     techStacks: z
       .array(z.object({ id: z.number(), name: z.string() }))
       .min(1, "기술 스택을 1개 이상 등록해 주세요."),
+    // 프로필 이미지는 선택값이라 File(업로드함) 또는 null(미업로드) 모두 허용한다.
     // File 전역이 없는 환경(SSR)에서 instanceof가 던지지 않도록 typeof로 가드한다.
     profileImage: z.custom<File | null>(
-      (file) => typeof File !== "undefined" && file instanceof File,
-      { message: "프로필 이미지를 업로드해 주세요." },
+      (file) =>
+        file === null || (typeof File !== "undefined" && file instanceof File),
+      { message: "올바른 이미지 파일이 아닙니다." },
     ),
   })
   // 목적이 '기타'일 때만 직접 입력값을 필수로 요구한다.

--- a/schemas/profile.ts
+++ b/schemas/profile.ts
@@ -1,0 +1,29 @@
+import { CUSTOM_PURPOSE } from "@/constants";
+import z from "zod";
+
+export const profileSchema = z
+  .object({
+    career: z.string().min(1, "개발 경력을 선택해 주세요."),
+    purpose: z.string().min(1, "공부 목적을 선택해 주세요."),
+    customPurpose: z.string(),
+    goal: z.string().min(1, "공부 목표를 입력해 주세요."),
+    techStacks: z
+      .array(z.object({ id: z.number(), name: z.string() }))
+      .min(1, "기술 스택을 1개 이상 등록해 주세요."),
+    // File 전역이 없는 환경(SSR)에서 instanceof가 던지지 않도록 typeof로 가드한다.
+    profileImage: z.custom<File | null>(
+      (file) => typeof File !== "undefined" && file instanceof File,
+      { message: "프로필 이미지를 업로드해 주세요." },
+    ),
+  })
+  // 목적이 '기타'일 때만 직접 입력값을 필수로 요구한다.
+  .refine(
+    (data) =>
+      data.purpose !== CUSTOM_PURPOSE || data.customPurpose.trim().length > 0,
+    {
+      message: "공부 목적을 입력해 주세요.",
+      path: ["customPurpose"],
+    },
+  );
+
+export type ProfileFormData = z.infer<typeof profileSchema>;

--- a/types/request.ts
+++ b/types/request.ts
@@ -13,3 +13,20 @@ export interface LoginRequest {
 export interface RefreshTokenRequest {
   refreshToken: string;
 }
+
+export interface PresignedUrlRequest {
+  fileName: string;
+  contentType: string;
+}
+
+export interface CreateProfileRequest {
+  career: string;
+  purpose: string;
+  goal: string;
+  techStacks: string[];
+  profileImage: string;
+}
+
+export interface CreateTechStackRequest {
+  name: string;
+}

--- a/types/response.ts
+++ b/types/response.ts
@@ -1,19 +1,21 @@
-export interface CheckDuplicateResponse {
+// 모든 API 응답이 공유하는 기본 형태
+export interface BaseResponse {
   success: boolean;
-  available: boolean;
   message: string;
 }
 
-export interface SignupResponse {
-  success: boolean;
-  message: string;
+// 구조가 동일한 응답들은 별칭으로 의미상 이름만 유지한다.
+export type SignupResponse = BaseResponse;
+export type LogoutResponse = BaseResponse;
+export type CreateProfileResponse = BaseResponse;
+
+export interface CheckDuplicateResponse extends BaseResponse {
+  available: boolean;
 }
 
 // 브라우저로 내려오는 로그인 응답. refreshToken은 BFF가 HttpOnly 쿠키로
 // 처리하므로 클라이언트 응답 바디에는 포함되지 않는다.
-export interface LoginResponse {
-  success: boolean;
-  message: string;
+export interface LoginResponse extends BaseResponse {
   accessToken: string;
   isFirstLogin: boolean;
   isDuplicateLogin: boolean;
@@ -24,12 +26,30 @@ export interface BackendLoginResponse extends LoginResponse {
   refreshToken: string;
 }
 
-export interface LogoutResponse {
-  success: boolean;
-  message: string;
-}
-
+// message가 없는 예외 케이스라 BaseResponse를 상속하지 않는다.
 export interface RefreshTokenResponse {
   success: boolean;
   accessToken: string;
+}
+
+export interface PresignedUrlResponse {
+  presignedUrl: string;
+  key: string;
+}
+
+export interface TechStack {
+  id: number;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TechStacksResponse {
+  results: TechStack[];
+}
+
+// POST /tech-stacks 응답: 생성된 항목을 techStack으로 감싸 반환한다.
+export interface CreateTechStackResponse {
+  message: string;
+  techStack: TechStack;
 }


### PR DESCRIPTION
## 📌관련 이슈

> #18 

## 📝작업 내용

-프로필 생성 / 기술스택 autocomplete 기능
프로필 생성 폼 및 제출 로직 구현 (경력·목적·목표·기술스택·프로필 이미지)
기술스택 검색 autocomplete 구현 — 디바운스 검색 + 매칭 결과 없을 시 신규 항목 생성
profile · tech-stack · presigned-url API 및 react-query 훅 추가
이미지 업로드(use-upload-image), 디바운스(use-debounce) 훅 추가
프로필 요청/응답 zod 스키마 및 타입 정의 추가
응답 타입을 BaseResponse로 공통화

-리팩터링
autocomplete의 상호작용 로직을 useAutoComplete 훅으로 분리하고 HighlightedName을 별도 컴포넌트로 추출 (UI와 로직 분리)
auth 쿼리 훅 반환값 네이밍 통일 (mutate → login/logout/signup/checkDuplicate)

-기타
confirm-modal 추가, 버튼 width 처리 조정


## 💻 스크린샷 (선택)

## 💬코멘트 (선택)
autocomplete는 현재 tech-stack 전용으로 구현했습니다. 다른 도메인에서 재사용이 필요해지면 데이터 소스를 주입받는 형태로 추상화할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 생성: 프로필 이미지 업로드와 기술 스택/목적/목표 입력 지원
  * 기술 스택 자동완성: 검색 결과 하이라이트 및 새 스택 생성
  * 프로필 설정 중단 시 확인 모달 제공
* **개선사항**
  * 폼 유효성 검증 강화 및 목적 “기타” 조건 처리
  * 제출 버튼 비활성화(업로드/요청 중) 및 버튼/모달 레이아웃 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->