### PR TITLE
feat: 학습 타이머 생성·복구·동기화·종료 기능 구현

### DIFF
--- a/apis/study-logs.ts
+++ b/apis/study-logs.ts
@@ -1,0 +1,12 @@
+import { ENDPOINTS } from "@/constants/endpoints";
+import { UpdateStudyLogRequest } from "@/types/request";
+import { GetStudyLogsResponse, UpdateStudyLogResponse } from "@/types/response";
+import { httpClient } from "./api-client";
+
+export const getStudyLog = (studyLogId: string) =>
+  httpClient.get<GetStudyLogsResponse>(`${ENDPOINTS.STUDY_LOGS}/${studyLogId}`);
+
+export const updateStudyLog = (
+  studyLogId: string,
+  data: UpdateStudyLogRequest,
+) => httpClient.put<UpdateStudyLogResponse>(`${studyLogId}/tasks`, data);

--- a/apis/timers.ts
+++ b/apis/timers.ts
@@ -1,0 +1,31 @@
+import { ENDPOINTS } from "@/constants/endpoints";
+import {
+  StartTimerRequest,
+  StopTimerRequest,
+  UpdateTimerRequest,
+} from "@/types/request";
+import {
+  GetTimerResponse,
+  StartTimerResponse,
+  StopTimerResponse,
+  UpdateTimerResponse,
+} from "@/types/response";
+import { httpClient } from "./api-client";
+
+export const getTimer = () =>
+  httpClient.get<GetTimerResponse>(ENDPOINTS.TIMERS);
+
+export const startTimer = (data: StartTimerRequest) =>
+  httpClient.post<StartTimerResponse>(ENDPOINTS.TIMERS, data);
+
+export const deleteTimer = (timerId: string) =>
+  httpClient.delete(`${ENDPOINTS.TIMERS}/${timerId}`);
+
+export const updateTimer = (timerId: string, data: UpdateTimerRequest) =>
+  httpClient.put<UpdateTimerResponse>(`${ENDPOINTS.TIMERS}/${timerId}`, data);
+
+export const stopTimer = (timerId: string, data: StopTimerRequest) =>
+  httpClient.post<StopTimerResponse>(
+    `${ENDPOINTS.TIMERS}/${timerId}/stop`,
+    data,
+  );

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,3 +1,4 @@
+import TimerBootstrap from "@/components/timer/timer-bootstrap";
 import TimerControls from "@/components/timer/timer-controls";
 import TimerDisplay from "@/components/timer/timer-display";
 import TimerHeader from "@/components/timer/timer-header";
@@ -5,6 +6,7 @@ import TimerHeader from "@/components/timer/timer-header";
 export default function Home() {
   return (
     <main className="flex flex-col items-center gap-20 py-20">
+      <TimerBootstrap />
       <TimerHeader />
       <TimerDisplay />
       <TimerControls />

--- a/components/common/helper-text/index.tsx
+++ b/components/common/helper-text/index.tsx
@@ -13,6 +13,7 @@ const themeVariants = {
   informative: `${base} text-primary`,
   error: `${base} text-negative`,
   success: `${base} text-positive`,
+  neutral: `${base} text-gray-400`,
 };
 
 export default function HelperText({

--- a/components/timer/session/goal-setup-modal.tsx
+++ b/components/timer/session/goal-setup-modal.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import { startTimer } from "@/apis/timers";
 import Button from "@/components/common/button";
 import InputField from "@/components/common/input-field";
 import TodoInput from "@/components/timer/todo/todo-input";
 import TodoList from "@/components/timer/todo/todo-list";
+import { useStartTimer } from "@/hooks/queries/use-start-timer";
 import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
-import { useTimerStore } from "@/store/use-timer-store";
-import { useMutation } from "@tanstack/react-query";
 
 // setup 국면: 목표 설정 + 할 일 생성/편집/삭제
 export default function GoalSetupModal() {
@@ -21,21 +19,16 @@ export default function GoalSetupModal() {
   const editContent = useSessionStore((s) => s.editContent);
   const stopEditing = useSessionStore((s) => s.stopEditing);
   const deleteTodo = useSessionStore((s) => s.deleteTodo);
-  const setPhase = useSessionStore((s) => s.setPhase);
-  const startTimerClock = useTimerStore((s) => s.start);
   const close = useModalStore((s) => s.close);
 
-  // POST /api/timers 성공 시에만 로컬 시계를 running으로 전환한다.
-  // 응답의 timerId/studyLogId를 시계에 주입해 서버 신원을 가진 세션으로 시작한다.
-  const { mutate: startSession, isPending } = useMutation({
-    mutationFn: () =>
-      startTimer({ todayGoal: goal, tasks: todos.map((t) => t.content) }),
-    onSuccess: ({ timerId, studyLogId }) => {
-      startTimerClock({ timerId, studyLogId });
-      setPhase("running");
-      close();
-    },
-  });
+  const { startTimer, isPending } = useStartTimer();
+
+  // 시계 전환(running)은 훅이 담당하고, 모달 닫기만 호출부에서 처리한다.
+  const handleStart = () =>
+    startTimer(
+      { todayGoal: goal, tasks: todos.map((t) => t.content) },
+      { onSuccess: close },
+    );
 
   return (
     <form
@@ -69,7 +62,7 @@ export default function GoalSetupModal() {
         <Button
           variant="Secondary"
           value="타이머 시작하기"
-          onClick={() => startSession()}
+          onClick={handleStart}
           // 목표 입력 + 할 일 최소 1개가 있어야 시작할 수 있다.
           disabled={!goal.trim() || todos.length === 0 || isPending}
         />

--- a/components/timer/session/goal-setup-modal.tsx
+++ b/components/timer/session/goal-setup-modal.tsx
@@ -26,7 +26,7 @@ export default function GoalSetupModal() {
   // 시계 전환(running)은 훅이 담당하고, 모달 닫기만 호출부에서 처리한다.
   const handleStart = () =>
     startTimer(
-      { todayGoal: goal, tasks: todos.map((t) => t.content) },
+      { todayGoal: goal.trim(), tasks: todos.map((t) => t.content) },
       { onSuccess: close },
     );
 
@@ -58,7 +58,12 @@ export default function GoalSetupModal() {
         className="h-110 overflow-y-auto"
       />
       <section className="flex justify-end gap-4">
-        <Button variant="Tertiary" value="취소" onClick={close} />
+        <Button
+          variant="Tertiary"
+          value="취소"
+          onClick={close}
+          disabled={isPending}
+        />
         <Button
           variant="Secondary"
           value="타이머 시작하기"

--- a/components/timer/session/goal-setup-modal.tsx
+++ b/components/timer/session/goal-setup-modal.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { startTimer } from "@/apis/timers";
 import Button from "@/components/common/button";
 import InputField from "@/components/common/input-field";
 import TodoInput from "@/components/timer/todo/todo-input";
 import TodoList from "@/components/timer/todo/todo-list";
+import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
+import { useTimerStore } from "@/store/use-timer-store";
+import { useMutation } from "@tanstack/react-query";
 
 // setup 국면: 목표 설정 + 할 일 생성/편집/삭제
 export default function GoalSetupModal() {
@@ -17,6 +21,21 @@ export default function GoalSetupModal() {
   const editContent = useSessionStore((s) => s.editContent);
   const stopEditing = useSessionStore((s) => s.stopEditing);
   const deleteTodo = useSessionStore((s) => s.deleteTodo);
+  const setPhase = useSessionStore((s) => s.setPhase);
+  const startTimerClock = useTimerStore((s) => s.start);
+  const close = useModalStore((s) => s.close);
+
+  // POST /api/timers 성공 시에만 로컬 시계를 running으로 전환한다.
+  // 응답의 timerId/studyLogId를 시계에 주입해 서버 신원을 가진 세션으로 시작한다.
+  const { mutate: startSession, isPending } = useMutation({
+    mutationFn: () =>
+      startTimer({ todayGoal: goal, tasks: todos.map((t) => t.content) }),
+    onSuccess: ({ timerId, studyLogId }) => {
+      startTimerClock({ timerId, studyLogId });
+      setPhase("running");
+      close();
+    },
+  });
 
   return (
     <form
@@ -28,6 +47,7 @@ export default function GoalSetupModal() {
         className="text-heading font-bold bg-white  focus:text-indigo"
         value={goal}
         onChange={(e) => setGoal(e.target.value)}
+        maxLength={30}
       />
       <TodoInput
         label="할 일 목록"
@@ -45,8 +65,14 @@ export default function GoalSetupModal() {
         className="h-110 overflow-y-auto"
       />
       <section className="flex justify-end gap-4">
-        <Button variant="Tertiary" value="취소" />
-        <Button variant="Secondary" value="타이머 시작하기" />
+        <Button variant="Tertiary" value="취소" onClick={close} />
+        <Button
+          variant="Secondary"
+          value="타이머 시작하기"
+          onClick={() => startSession()}
+          // 목표 입력 + 할 일 최소 1개가 있어야 시작할 수 있다.
+          disabled={!goal.trim() || todos.length === 0 || isPending}
+        />
       </section>
     </form>
   );

--- a/components/timer/session/session-review-modal.tsx
+++ b/components/timer/session/session-review-modal.tsx
@@ -93,7 +93,13 @@ export default function SessionReviewModal() {
         </div>
       </div>
       <section className="flex justify-end gap-4">
-        <Button variant="Tertiary" value="취소" onClick={handleCancel} />
+        <Button
+          variant="Tertiary"
+          value="취소"
+          onClick={handleCancel}
+          // 완료 요청 진행 중 취소하면, 뒤늦게 온 성공 응답이 되돌린 세션까지 지운다.
+          disabled={isPending}
+        />
         <Button
           variant="Secondary"
           value="공부 완료하기"

--- a/components/timer/session/session-review-modal.tsx
+++ b/components/timer/session/session-review-modal.tsx
@@ -1,19 +1,67 @@
 "use client";
 
+import { stopTimer } from "@/apis/timers";
 import Button from "@/components/common/button";
+import HelperText from "@/components/common/helper-text";
 import TextAreaField from "@/components/common/textarea-field";
 import TodoInput from "@/components/timer/todo/todo-input";
 import TodoList from "@/components/timer/todo/todo-list";
+import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
+import { useTimerStore } from "@/store/use-timer-store";
+import type { StopTimerRequest } from "@/types/request";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-// review 국면: 타이머 종료 후 결과 확인 + 한 줄 소감 작성
-// TODO: 저장 푸터 + completeSession 뮤테이션 연동
+const MIN_REVIEW_LENGTH = 15; // 학습 회고 최소 글자 수
+const MAX_REVIEW_LENGTH = 500; // 학습 회고 최대 글자 수
+
+// review 국면: 타이머 종료 후 결과 확인 + 한 줄 소감 작성 → stopTimer로 세션 확정
 export default function SessionReviewModal() {
   const todos = useSessionStore((s) => s.todos);
   const reflection = useSessionStore((s) => s.reflection);
   const setReflection = useSessionStore((s) => s.setReflection);
   const addTodo = useSessionStore((s) => s.addTodo);
   const toggleTodo = useSessionStore((s) => s.toggleTodo);
+  const setPhase = useSessionStore((s) => s.setPhase);
+
+  const timerId = useTimerStore((s) => s.timerId);
+  const close = useModalStore((s) => s.close);
+  const queryClient = useQueryClient();
+
+  const { mutate: finishSession, isPending } = useMutation({
+    mutationFn: () => {
+      if (!timerId) throw new Error("종료할 타이머가 없습니다.");
+
+      const payload: StopTimerRequest = {
+        // 종료 직전 pause()로 진행 구간이 커밋된 일자별 경과를 그대로 보낸다.
+        splitTimes: useTimerStore.getState().getSplitTimesSnapshot(),
+        review: reflection.trim(),
+        tasks: todos.map((t) => ({
+          content: t.content,
+          isCompleted: t.done,
+        })),
+      };
+      return stopTimer(timerId, payload);
+    },
+    onSuccess: () => {
+      // 세션 확정 완료 → 로컬 시계·세션·저장분을 모두 비운다(로그아웃 정리와 동일 패턴).
+      useTimerStore.getState().reset();
+      useSessionStore.getState().reset();
+      useTimerStore.persist.clearStorage();
+      useSessionStore.persist.clearStorage();
+      // 종료된 타이머가 부트스트랩에서 다시 복구되지 않도록 캐시 제거.
+      queryClient.removeQueries({ queryKey: ["timer"] });
+      close();
+    },
+  });
+
+  // 종료를 취소하면 진행 중이던(일시정지된) 세션으로 돌아간다.
+  const handleCancel = () => {
+    setPhase("running");
+    close();
+  };
+
+  const isReviewValid = reflection.trim().length >= MIN_REVIEW_LENGTH;
 
   return (
     <form
@@ -35,16 +83,40 @@ export default function SessionReviewModal() {
         onToggle={toggleTodo}
         className="h-80 overflow-y-auto"
       />
-      <TextAreaField
-        label="학습 회고"
-        placeholder="오늘 학습한 내용을 회고해 보세요(15자 이상 작성 필수)"
-        value={reflection}
-        onChange={(e) => setReflection(e.target.value)}
-      />
-      {/* TODO: 저장 버튼 */}
+      <div className="flex flex-col gap-2">
+        <TextAreaField
+          label="학습 회고"
+          placeholder="오늘 학습한 내용을 회고해 보세요(15자 이상 작성 필수)"
+          value={reflection}
+          onChange={(e) => setReflection(e.target.value)}
+          maxLength={MAX_REVIEW_LENGTH}
+        />
+        <div className="flex items-center">
+          {/* 최소 글자 미달일 때만 안내. 충족되면 사라진다. */}
+          {!isReviewValid && (
+            <HelperText
+              status="error"
+              message={`최소 ${MIN_REVIEW_LENGTH}자 이상 작성해주세요`}
+            />
+          )}
+          {/* 현재/최대 글자 수. 상한(500)에 도달하면 강조. ml-auto로 항상 우측. */}
+          <HelperText
+            status={
+              reflection.length >= MAX_REVIEW_LENGTH ? "error" : "neutral"
+            }
+            message={`${reflection.length}/${MAX_REVIEW_LENGTH}`}
+            className="ml-auto"
+          />
+        </div>
+      </div>
       <section className="flex justify-end gap-4">
-        <Button variant="Tertiary" value="취소" />
-        <Button variant="Secondary" value="공부 완료하기" />
+        <Button variant="Tertiary" value="취소" onClick={handleCancel} />
+        <Button
+          variant="Secondary"
+          value="공부 완료하기"
+          onClick={() => finishSession()}
+          disabled={!isReviewValid || !timerId || isPending}
+        />
       </section>
     </form>
   );

--- a/components/timer/session/session-review-modal.tsx
+++ b/components/timer/session/session-review-modal.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { stopTimer } from "@/apis/timers";
 import Button from "@/components/common/button";
 import HelperText from "@/components/common/helper-text";
 import TextAreaField from "@/components/common/textarea-field";
 import TodoInput from "@/components/timer/todo/todo-input";
 import TodoList from "@/components/timer/todo/todo-list";
+import { useStopTimer } from "@/hooks/queries/use-stop-timer";
 import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
 import { useTimerStore } from "@/store/use-timer-store";
 import type { StopTimerRequest } from "@/types/request";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const MIN_REVIEW_LENGTH = 15; // 학습 회고 최소 글자 수
 const MAX_REVIEW_LENGTH = 500; // 학습 회고 최대 글자 수
@@ -26,34 +25,18 @@ export default function SessionReviewModal() {
 
   const timerId = useTimerStore((s) => s.timerId);
   const close = useModalStore((s) => s.close);
-  const queryClient = useQueryClient();
+  const { stopTimer, isPending } = useStopTimer();
 
-  const { mutate: finishSession, isPending } = useMutation({
-    mutationFn: () => {
-      if (!timerId) throw new Error("종료할 타이머가 없습니다.");
-
-      const payload: StopTimerRequest = {
-        // 종료 직전 pause()로 진행 구간이 커밋된 일자별 경과를 그대로 보낸다.
-        splitTimes: useTimerStore.getState().getSplitTimesSnapshot(),
-        review: reflection.trim(),
-        tasks: todos.map((t) => ({
-          content: t.content,
-          isCompleted: t.done,
-        })),
-      };
-      return stopTimer(timerId, payload);
-    },
-    onSuccess: () => {
-      // 세션 확정 완료 → 로컬 시계·세션·저장분을 모두 비운다(로그아웃 정리와 동일 패턴).
-      useTimerStore.getState().reset();
-      useSessionStore.getState().reset();
-      useTimerStore.persist.clearStorage();
-      useSessionStore.persist.clearStorage();
-      // 종료된 타이머가 부트스트랩에서 다시 복구되지 않도록 캐시 제거.
-      queryClient.removeQueries({ queryKey: ["timer"] });
-      close();
-    },
-  });
+  // 세션 정리·캐시 제거는 훅이 담당하고, 모달 닫기만 호출부에서 처리한다.
+  const handleFinish = () => {
+    const payload: StopTimerRequest = {
+      // 종료 직전 pause()로 진행 구간이 커밋된 일자별 경과를 그대로 보낸다.
+      splitTimes: useTimerStore.getState().getSplitTimesSnapshot(),
+      review: reflection.trim(),
+      tasks: todos.map((t) => ({ content: t.content, isCompleted: t.done })),
+    };
+    stopTimer(payload, { onSuccess: close });
+  };
 
   // 종료를 취소하면 진행 중이던(일시정지된) 세션으로 돌아간다.
   const handleCancel = () => {
@@ -114,7 +97,7 @@ export default function SessionReviewModal() {
         <Button
           variant="Secondary"
           value="공부 완료하기"
-          onClick={() => finishSession()}
+          onClick={handleFinish}
           disabled={!isReviewValid || !timerId || isPending}
         />
       </section>

--- a/components/timer/session/todo-checklist-modal.tsx
+++ b/components/timer/session/todo-checklist-modal.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { updateStudyLog } from "@/apis/study-logs";
 import EditIcon from "@/assets/icons/edit.svg";
 import Button from "@/components/common/button";
 import TodoInput from "@/components/timer/todo/todo-input";
 import TodoList from "@/components/timer/todo/todo-list";
+import { useUpdateStudyLog } from "@/hooks/queries/use-update-study-log";
 import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
 import { useTimerStore } from "@/store/use-timer-store";
-import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
 // running 국면: 타이머 진행 중 할 일 체크
@@ -27,21 +26,7 @@ export default function TodoChecklistModal() {
   const studyLogId = useTimerStore((s) => s.studyLogId);
   const close = useModalStore((s) => s.close);
 
-  // 할 일 목록을 서버에 저장한다(PUT /api/study-logs/{studyLogId}/tasks).
-  const { mutate: saveTasks, isPending } = useMutation({
-    mutationFn: () => {
-      if (!studyLogId) throw new Error("저장할 학습 로그가 없습니다.");
-      return updateStudyLog(studyLogId, {
-        tasks: todos.map((t) => ({
-          content: t.content,
-          isCompleted: t.done,
-        })),
-      });
-    },
-    onError: (error) => {
-      console.error("할 일 목록 저장 실패:", error);
-    },
-  });
+  const { updateStudyLog, isPending } = useUpdateStudyLog();
 
   const handleEditClick = () => {
     setIsEdit((prev) => {
@@ -58,7 +43,9 @@ export default function TodoChecklistModal() {
       setIsEdit(false);
       return;
     }
-    saveTasks();
+    updateStudyLog(
+      todos.map((t) => ({ content: t.content, isCompleted: t.done })),
+    );
   };
 
   // 수정 모드에선 setup처럼 adding/editing 카드로 렌더한다.

--- a/components/timer/session/todo-checklist-modal.tsx
+++ b/components/timer/session/todo-checklist-modal.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { updateStudyLog } from "@/apis/study-logs";
 import EditIcon from "@/assets/icons/edit.svg";
 import Button from "@/components/common/button";
 import TodoInput from "@/components/timer/todo/todo-input";
 import TodoList from "@/components/timer/todo/todo-list";
+import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
+import { useTimerStore } from "@/store/use-timer-store";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
 // running 국면: 타이머 진행 중 할 일 체크
@@ -20,12 +24,41 @@ export default function TodoChecklistModal() {
   const editContent = useSessionStore((s) => s.editContent);
   const stopEditing = useSessionStore((s) => s.stopEditing);
   const deleteTodo = useSessionStore((s) => s.deleteTodo);
+  const studyLogId = useTimerStore((s) => s.studyLogId);
+  const close = useModalStore((s) => s.close);
+
+  // 할 일 목록을 서버에 저장한다(PUT /api/study-logs/{studyLogId}/tasks).
+  const { mutate: saveTasks, isPending } = useMutation({
+    mutationFn: () => {
+      if (!studyLogId) throw new Error("저장할 학습 로그가 없습니다.");
+      return updateStudyLog(studyLogId, {
+        tasks: todos.map((t) => ({
+          content: t.content,
+          isCompleted: t.done,
+        })),
+      });
+    },
+    onError: (error) => {
+      console.error("할 일 목록 저장 실패:", error);
+    },
+  });
 
   const handleEditClick = () => {
     setIsEdit((prev) => {
       if (prev) stopEditing(); // 수정 모드 종료 시 편집 중이던 항목 정리
       return !prev;
     });
+  };
+
+  // 수정 모드("변경사항 저장하기")에서는 서버 저장 없이 수정 모드만 종료하고,
+  // 일반 모드("저장하기")에서만 서버에 할 일 목록을 저장한다.
+  const handleSaveClick = () => {
+    if (isEdit) {
+      stopEditing(); // 편집 중이던 항목 정리
+      setIsEdit(false);
+      return;
+    }
+    saveTasks();
   };
 
   // 수정 모드에선 setup처럼 adding/editing 카드로 렌더한다.
@@ -64,12 +97,13 @@ export default function TodoChecklistModal() {
         />
       </section>
 
-      {/* TODO: 닫기 버튼 */}
       <section className="flex justify-end gap-4">
-        <Button variant="Tertiary" value="취소" />
+        <Button variant="Tertiary" value="취소" onClick={close} />
         <Button
           variant="Secondary"
           value={isEdit ? "변경사항 저장하기" : "저장하기"}
+          onClick={handleSaveClick}
+          disabled={(!isEdit && !studyLogId) || isPending}
         />
       </section>
     </form>

--- a/components/timer/timer-bootstrap.tsx
+++ b/components/timer/timer-bootstrap.tsx
@@ -5,7 +5,7 @@ import { useStudyLog } from "@/hooks/queries/use-study-log";
 import { useTimerHeartbeat } from "@/hooks/use-timer-heartbeat";
 import { useSessionStore } from "@/store/use-session-store";
 import { useTimerStore } from "@/store/use-timer-store";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // 타이머 페이지에 머무는 동안 상시 마운트되는(화면엔 안 보이는) 컴포넌트로,
 // 두 가지 백그라운드 작업을 담당한다.
@@ -23,46 +23,56 @@ export default function TimerBootstrap() {
   // running 중 10분마다 서버로 경과를 동기화한다(status 기반 자동 시작/정지).
   useTimerHeartbeat();
 
-  // 로컬에 활성 세션이 있었는지 여부. 반드시 서버 복구 "이전" 시점의 스냅샷이어야 한다.
-  // store의 status에서 파생하면 hydrateFromServer가 status를 바꾸는 순간 true로
-  // 뒤집혀, 뒤이어 받아야 할 study-log 조회가 스스로 막힌다(목표·할 일 유실).
+  // 로컬에 활성 세션이 있었는지 여부. 반드시 localStorage 복원 "이후, 서버 복구 이전"
+  // 시점의 스냅샷이어야 한다. store의 status에서 파생하면 hydrateFromServer가 status를
+  // 바꾸는 순간 true로 뒤집혀, 뒤이어 받아야 할 study-log 조회가 스스로 막힌다.
   const hadLocalSession = useRef(false);
 
-  // skipHydration으로 꺼 둔 persist를 클라이언트 마운트 후 명시적으로 복구한다.
+  // localStorage 복원(persist rehydrate) 완료 여부. 이 값이 true가 되기 전에는 서버
+  // 하이드레이션을 절대 실행하지 않는다(아래 두 effect 게이트). 복원은 비동기(await)라
+  // hadLocalSession 확정이 지연되는데, 서버 쿼리가 cache hit으로 먼저 성공하면
+  // hadLocalSession이 미확정인 채 하이드레이션이 튀어 시계/세션이 서로 다른 소스에서
+  // 채워질 수 있다(시계와 목표·할 일이 다른 세션에 연결). 이를 막기 위한 게이트.
+  const [isRehydrated, setIsRehydrated] = useState(false);
+
+  // skipHydration으로 꺼 둔 persist를 클라이언트 마운트 후 명시적으로 복원한다.
   // (SSR 하이드레이션 불일치 방지)
   useEffect(() => {
-    const rehydrate = async () => {
+    const restore = async () => {
       // rehydrate()는 Promise를 반환한다. 지금은 localStorage(동기)라 즉시 반영되지만,
-      // 비동기 스토리지로 바뀌어도 재수화 완료 후에 보정·스냅샷이 실행되도록 await한다.
+      // 비동기 스토리지로 바뀌어도 복원 완료 후에 보정·스냅샷·게이트 해제가 실행되도록 await한다.
       await Promise.all([
         useTimerStore.persist.rehydrate(),
         useSessionStore.persist.rehydrate(),
       ]);
 
-      // 크래시로 running 그대로 복구된 경우 오프라인 구간을 버리고 paused로 정규화한다.
+      // 크래시로 running 그대로 복원된 경우 오프라인 구간을 버리고 paused로 정규화한다.
       // (서버 조회보다 앞서 로컬을 안전화한 뒤 hadLocalSession을 확정)
       useTimerStore.getState().discardStaleRun();
       hadLocalSession.current = useTimerStore.getState().status !== "idle";
+      setIsRehydrated(true); // 복원 완료 → 이제부터 서버 하이드레이션 허용
     };
 
-    void rehydrate();
+    void restore();
   }, []);
 
   const { timer } = useActiveTimer();
   const { studyLog } = useStudyLog(timer?.studyLogId);
 
   useEffect(() => {
-    if (timer && !hadLocalSession.current) {
+    // 복원 완료(isRehydrated) 전에는 실행하지 않는다. cache hit으로 timer가 일찍 와도,
+    // hadLocalSession이 확정된 뒤에야 판정해 시계/세션이 같은 소스로 일관되게 채워진다.
+    if (isRehydrated && timer && !hadLocalSession.current) {
       useTimerStore.getState().hydrateFromServer(timer);
     }
-  }, [timer]);
+  }, [isRehydrated, timer]);
 
   useEffect(() => {
-    // 로컬 세션이 있었다면 goal·todos는 localStorage에서 복구되므로 서버 값으로 덮지 않는다.
-    if (studyLog && !hadLocalSession.current) {
+    // 로컬 세션이 있었다면 goal·todos는 localStorage에서 복원되므로 서버 값으로 덮지 않는다.
+    if (isRehydrated && studyLog && !hadLocalSession.current) {
       useSessionStore.getState().hydrateFromStudyLog(studyLog.data);
     }
-  }, [studyLog]);
+  }, [isRehydrated, studyLog]);
 
   return null;
 }

--- a/components/timer/timer-bootstrap.tsx
+++ b/components/timer/timer-bootstrap.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { getStudyLog } from "@/apis/study-logs";
-import { getTimer } from "@/apis/timers";
+import { useActiveTimer } from "@/hooks/queries/use-active-timer";
+import { useStudyLog } from "@/hooks/queries/use-study-log";
 import { useTimerHeartbeat } from "@/hooks/use-timer-heartbeat";
-import { useAuthStore } from "@/store/use-auth-store";
 import { useSessionStore } from "@/store/use-session-store";
 import { useTimerStore } from "@/store/use-timer-store";
-import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 
 // 타이머 페이지에 머무는 동안 상시 마운트되는(화면엔 안 보이는) 컴포넌트로,
@@ -22,8 +20,6 @@ import { useEffect, useRef } from "react";
 //
 // 2) 폴링(heartbeat) — useTimerHeartbeat로 running 중 10분마다 서버에 경과를 동기화.
 export default function TimerBootstrap() {
-  const accessToken = useAuthStore((s) => s.accessToken);
-
   // running 중 10분마다 서버로 경과를 동기화한다(status 기반 자동 시작/정지).
   useTimerHeartbeat();
 
@@ -41,28 +37,8 @@ export default function TimerBootstrap() {
     hadLocalSession.current = useTimerStore.getState().status !== "idle";
   }, []);
 
-  const { data: timer } = useQuery({
-    queryKey: ["timer"],
-    queryFn: getTimer,
-    enabled: !!accessToken, // silent refresh로 토큰이 채워진 뒤에만 조회
-    retry: false,
-    // 진입 시 1회만 복구하는 부트스트랩. 이후 refetch가 로컬 시계 상태
-    // (start/pause 등)를 덮어쓰지 않도록 재요청을 끈다.
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-  });
-
-  const studyLogId = timer?.studyLogId;
-
-  const { data: studyLog } = useQuery({
-    queryKey: ["study-log", studyLogId],
-    queryFn: () => getStudyLog(studyLogId!),
-    enabled: !!studyLogId, // 미종료 타이머가 있을 때만 조회
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-  });
+  const { timer } = useActiveTimer();
+  const { studyLog } = useStudyLog(timer?.studyLogId);
 
   useEffect(() => {
     if (timer && !hadLocalSession.current) {

--- a/components/timer/timer-bootstrap.tsx
+++ b/components/timer/timer-bootstrap.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { getStudyLog } from "@/apis/study-logs";
+import { getTimer } from "@/apis/timers";
+import { useTimerHeartbeat } from "@/hooks/use-timer-heartbeat";
+import { useAuthStore } from "@/store/use-auth-store";
+import { useSessionStore } from "@/store/use-session-store";
+import { useTimerStore } from "@/store/use-timer-store";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+// 타이머 페이지에 머무는 동안 상시 마운트되는(화면엔 안 보이는) 컴포넌트로,
+// 두 가지 백그라운드 작업을 담당한다.
+//
+// 1) 미종료 타이머 복구 — 진입 시 아래 두 소스 중 하나로 시계·세션을 되살린다.
+//    - localStorage(로컬): 새로고침 등으로 메모리가 날아가도 진행 중이던 시계를 유지.
+//      서버는 폴링(10분)·일시정지·종료 시점에만 갱신돼 최대 10분 뒤처질 수 있으므로,
+//      로컬 세션이 살아있으면 가장 최신인 로컬을 우선한다.
+//    - 서버(GET /api/timers): 다른 기기/최초 로그인처럼 로컬에 세션이 없을 때만 사용.
+//      있으면 studyLogId로 GET /api/study-logs/{id}까지 받아 세션 내용을 채운다.
+//    둘 다 없으면 두 스토어 모두 초기(idle)로 남아 타이머 페이지는 초기 상태로 랜딩.
+//
+// 2) 폴링(heartbeat) — useTimerHeartbeat로 running 중 10분마다 서버에 경과를 동기화.
+export default function TimerBootstrap() {
+  const accessToken = useAuthStore((s) => s.accessToken);
+
+  // running 중 10분마다 서버로 경과를 동기화한다(status 기반 자동 시작/정지).
+  useTimerHeartbeat();
+
+  // 로컬에 활성 세션이 있었는지 여부. 반드시 서버 복구 "이전" 시점의 스냅샷이어야 한다.
+  // store의 status에서 파생하면 hydrateFromServer가 status를 바꾸는 순간 true로
+  // 뒤집혀, 뒤이어 받아야 할 study-log 조회가 스스로 막힌다(목표·할 일 유실).
+  const hadLocalSession = useRef(false);
+
+  // skipHydration으로 꺼 둔 persist를 클라이언트 마운트 후 명시적으로 복구한다.
+  // (SSR 하이드레이션 불일치 방지)
+  useEffect(() => {
+    useTimerStore.persist.rehydrate();
+    useSessionStore.persist.rehydrate();
+    // localStorage는 동기 스토리지라 rehydrate 직후 상태가 반영돼 있다.
+    hadLocalSession.current = useTimerStore.getState().status !== "idle";
+  }, []);
+
+  const { data: timer } = useQuery({
+    queryKey: ["timer"],
+    queryFn: getTimer,
+    enabled: !!accessToken, // silent refresh로 토큰이 채워진 뒤에만 조회
+    retry: false,
+    // 진입 시 1회만 복구하는 부트스트랩. 이후 refetch가 로컬 시계 상태
+    // (start/pause 등)를 덮어쓰지 않도록 재요청을 끈다.
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  const studyLogId = timer?.studyLogId;
+
+  const { data: studyLog } = useQuery({
+    queryKey: ["study-log", studyLogId],
+    queryFn: () => getStudyLog(studyLogId!),
+    enabled: !!studyLogId, // 미종료 타이머가 있을 때만 조회
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  useEffect(() => {
+    if (timer && !hadLocalSession.current) {
+      useTimerStore.getState().hydrateFromServer(timer);
+    }
+  }, [timer]);
+
+  useEffect(() => {
+    // 로컬 세션이 있었다면 goal·todos는 localStorage에서 복구되므로 서버 값으로 덮지 않는다.
+    if (studyLog && !hadLocalSession.current) {
+      useSessionStore.getState().hydrateFromStudyLog(studyLog.data);
+    }
+  }, [studyLog]);
+
+  return null;
+}

--- a/components/timer/timer-bootstrap.tsx
+++ b/components/timer/timer-bootstrap.tsx
@@ -31,10 +31,21 @@ export default function TimerBootstrap() {
   // skipHydration으로 꺼 둔 persist를 클라이언트 마운트 후 명시적으로 복구한다.
   // (SSR 하이드레이션 불일치 방지)
   useEffect(() => {
-    useTimerStore.persist.rehydrate();
-    useSessionStore.persist.rehydrate();
-    // localStorage는 동기 스토리지라 rehydrate 직후 상태가 반영돼 있다.
-    hadLocalSession.current = useTimerStore.getState().status !== "idle";
+    const rehydrate = async () => {
+      // rehydrate()는 Promise를 반환한다. 지금은 localStorage(동기)라 즉시 반영되지만,
+      // 비동기 스토리지로 바뀌어도 재수화 완료 후에 보정·스냅샷이 실행되도록 await한다.
+      await Promise.all([
+        useTimerStore.persist.rehydrate(),
+        useSessionStore.persist.rehydrate(),
+      ]);
+
+      // 크래시로 running 그대로 복구된 경우 오프라인 구간을 버리고 paused로 정규화한다.
+      // (서버 조회보다 앞서 로컬을 안전화한 뒤 hadLocalSession을 확정)
+      useTimerStore.getState().discardStaleRun();
+      hadLocalSession.current = useTimerStore.getState().status !== "idle";
+    };
+
+    void rehydrate();
   }, []);
 
   const { timer } = useActiveTimer();

--- a/components/timer/timer-controls.tsx
+++ b/components/timer/timer-controls.tsx
@@ -1,34 +1,113 @@
 "use client";
 
+import { deleteTimer, updateTimer } from "@/apis/timers";
 import FinishIcon from "@/assets/icons/finish.svg";
 import PauseIcon from "@/assets/icons/pause.svg";
 import ResetIcon from "@/assets/icons/reset.svg";
 import StartIcon from "@/assets/icons/start.svg";
 import TodoIcon from "@/assets/icons/todo.svg";
+import ConfirmModal from "@/components/common/modal/confirm-modal";
 import ControlButton from "@/components/timer/control-button";
 import GoalSetupModal from "@/components/timer/session/goal-setup-modal";
 import SessionReviewModal from "@/components/timer/session/session-review-modal";
 import TodoChecklistModal from "@/components/timer/session/todo-checklist-modal";
 import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
+import { useTimerStore } from "@/store/use-timer-store";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function TimerControls() {
   const open = useModalStore((state) => state.open);
-  const setPhase = useSessionStore((state) => state.setPhase);
 
+  const setPhase = useSessionStore((state) => state.setPhase);
+  const resetSession = useSessionStore((state) => state.reset);
+
+  const status = useTimerStore((state) => state.status);
+  const timerId = useTimerStore((state) => state.timerId);
+  const pause = useTimerStore((state) => state.pause);
+  const resume = useTimerStore((state) => state.resume);
+  const resetTimer = useTimerStore((state) => state.reset);
+
+  const queryClient = useQueryClient();
+
+  // 일시정지 시 현재까지의 일자별 경과를 서버에 동기화한다(PUT /api/timers/{timerId}).
+  const { mutate: syncSplitsToServer } = useMutation({
+    mutationFn: (id: string) =>
+      updateTimer(id, {
+        splitTimes: useTimerStore.getState().getSplitTimesSnapshot(),
+      }),
+    onError: (error) => {
+      // 동기화 실패해도 로컬 일시정지는 유지된다(다음 일시정지/종료 때 재반영).
+      console.error("타이머 동기화 실패:", error);
+    },
+  });
+
+  // 타이머 초기화: 서버의 타이머를 삭제한다(DELETE /api/timers/{timerId}).
+  const { mutate: removeTimer, isPending: isResetting } = useMutation({
+    mutationFn: (id: string) => deleteTimer(id),
+    // 서버에서 지워진 뒤에만 로컬을 비운다. 먼저 비우면 삭제 실패 시
+    // 서버에는 타이머가 남아 다음 진입에서 되살아난다.
+    onSuccess: () => {
+      resetTimer();
+      resetSession();
+      useTimerStore.persist.clearStorage();
+      useSessionStore.persist.clearStorage();
+      // 삭제된 타이머가 부트스트랩에서 다시 복구되지 않도록 캐시 제거.
+      queryClient.removeQueries({ queryKey: ["timer"] });
+    },
+    onError: (error) => {
+      console.error("타이머 초기화 실패:", error);
+    },
+  });
+
+  // idle: 새 세션 시작(모달) / paused: 복구·일시정지된 세션 재개
   const handleStartClick = () => {
+    if (status === "paused") {
+      resume();
+      return;
+    }
     open(<GoalSetupModal />);
   };
 
+  const handlePauseClick = () => {
+    pause();
+    // pause()가 진행 구간을 splits에 커밋한 직후의 일자별 경과를 서버에 반영한다.
+    if (timerId) syncSplitsToServer(timerId);
+  };
+
   const handleFinishClick = () => {
+    pause(); // 종료 확정 전까지 시계를 멈춘다
     setPhase("review");
     open(<SessionReviewModal />);
+  };
+
+  // 초기화 확인 모달을 띄우고, "초기화하기"를 눌렀을 때만 삭제 API를 호출한다.
+  const handleResetClick = () => {
+    if (!timerId) return;
+    open(
+      <ConfirmModal
+        title="기록을 초기화 하시겠습니까?"
+        description={
+          "진행되던 타이머 기록은 삭제되고, 복구가 불가능합니다. 계속 초기화 할까요?"
+        }
+        confirmText="초기화하기"
+        cancelText="취소"
+        onConfirm={() => removeTimer(timerId)}
+      />,
+    );
   };
 
   const handleTodoClick = () => {
     setPhase("running");
     open(<TodoChecklistModal />);
   };
+
+  // 상태별 활성 여부. 색상(text-primary/text-primary-10)과 disabled에 함께 쓴다.
+  const startDisabled = status === "running";
+  const pauseDisabled = status !== "running";
+  const finishDisabled = status === "idle";
+  const colorOf = (disabled: boolean) =>
+    disabled ? "text-primary-10" : "text-primary";
 
   return (
     <div className="relative flex w-full items-center justify-center">
@@ -37,36 +116,44 @@ export default function TimerControls() {
         <ControlButton
           label="시작"
           icon={<StartIcon className="h-16 w-16" />}
-          className="text-primary"
+          className={colorOf(startDisabled)}
           onClick={handleStartClick}
+          disabled={startDisabled}
         />
         <ControlButton
           label="일시정지"
           icon={<PauseIcon className="h-16 w-16" />}
-          className="text-primary-10"
+          className={colorOf(pauseDisabled)}
+          onClick={handlePauseClick}
+          disabled={pauseDisabled}
         />
         <ControlButton
           label="타이머 종료"
           icon={<FinishIcon className="h-16 w-16" />}
-          className="text-primary-10"
+          className={colorOf(finishDisabled)}
           onClick={handleFinishClick}
+          disabled={finishDisabled}
         />
       </div>
 
-      {/* 우측 보조 버튼 */}
-      <div className="absolute right-0 flex items-center gap-4">
-        <ControlButton
-          label="할 일 목록"
-          variant="round"
-          icon={<TodoIcon className="h-12 w-12" />}
-          onClick={handleTodoClick}
-        />
-        <ControlButton
-          label="타이머 초기화"
-          variant="round"
-          icon={<ResetIcon className="h-12 w-12" />}
-        />
-      </div>
+      {/* 우측 보조 버튼: 타이머가 존재할 때(timerId 있음)만 렌더링 */}
+      {timerId && (
+        <div className="absolute right-0 flex items-center gap-4">
+          <ControlButton
+            label="할 일 목록"
+            variant="round"
+            icon={<TodoIcon className="h-12 w-12" />}
+            onClick={handleTodoClick}
+          />
+          <ControlButton
+            label="타이머 초기화"
+            variant="round"
+            icon={<ResetIcon className="h-12 w-12" />}
+            onClick={handleResetClick}
+            disabled={isResetting}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/timer/timer-controls.tsx
+++ b/components/timer/timer-controls.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { deleteTimer, updateTimer } from "@/apis/timers";
 import FinishIcon from "@/assets/icons/finish.svg";
 import PauseIcon from "@/assets/icons/pause.svg";
 import ResetIcon from "@/assets/icons/reset.svg";
@@ -11,54 +10,23 @@ import ControlButton from "@/components/timer/control-button";
 import GoalSetupModal from "@/components/timer/session/goal-setup-modal";
 import SessionReviewModal from "@/components/timer/session/session-review-modal";
 import TodoChecklistModal from "@/components/timer/session/todo-checklist-modal";
+import { useDeleteTimer } from "@/hooks/queries/use-delete-timer";
+import { useSyncTimer } from "@/hooks/queries/use-sync-timer";
 import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
 import { useTimerStore } from "@/store/use-timer-store";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function TimerControls() {
   const open = useModalStore((state) => state.open);
-
   const setPhase = useSessionStore((state) => state.setPhase);
-  const resetSession = useSessionStore((state) => state.reset);
 
   const status = useTimerStore((state) => state.status);
   const timerId = useTimerStore((state) => state.timerId);
   const pause = useTimerStore((state) => state.pause);
   const resume = useTimerStore((state) => state.resume);
-  const resetTimer = useTimerStore((state) => state.reset);
 
-  const queryClient = useQueryClient();
-
-  // 일시정지 시 현재까지의 일자별 경과를 서버에 동기화한다(PUT /api/timers/{timerId}).
-  const { mutate: syncSplitsToServer } = useMutation({
-    mutationFn: (id: string) =>
-      updateTimer(id, {
-        splitTimes: useTimerStore.getState().getSplitTimesSnapshot(),
-      }),
-    onError: (error) => {
-      // 동기화 실패해도 로컬 일시정지는 유지된다(다음 일시정지/종료 때 재반영).
-      console.error("타이머 동기화 실패:", error);
-    },
-  });
-
-  // 타이머 초기화: 서버의 타이머를 삭제한다(DELETE /api/timers/{timerId}).
-  const { mutate: removeTimer, isPending: isResetting } = useMutation({
-    mutationFn: (id: string) => deleteTimer(id),
-    // 서버에서 지워진 뒤에만 로컬을 비운다. 먼저 비우면 삭제 실패 시
-    // 서버에는 타이머가 남아 다음 진입에서 되살아난다.
-    onSuccess: () => {
-      resetTimer();
-      resetSession();
-      useTimerStore.persist.clearStorage();
-      useSessionStore.persist.clearStorage();
-      // 삭제된 타이머가 부트스트랩에서 다시 복구되지 않도록 캐시 제거.
-      queryClient.removeQueries({ queryKey: ["timer"] });
-    },
-    onError: (error) => {
-      console.error("타이머 초기화 실패:", error);
-    },
-  });
+  const { syncTimer } = useSyncTimer();
+  const { deleteTimer, isPending: isResetting } = useDeleteTimer();
 
   // idle: 새 세션 시작(모달) / paused: 복구·일시정지된 세션 재개
   const handleStartClick = () => {
@@ -72,7 +40,7 @@ export default function TimerControls() {
   const handlePauseClick = () => {
     pause();
     // pause()가 진행 구간을 splits에 커밋한 직후의 일자별 경과를 서버에 반영한다.
-    if (timerId) syncSplitsToServer(timerId);
+    if (timerId) syncTimer(timerId);
   };
 
   const handleFinishClick = () => {
@@ -92,7 +60,7 @@ export default function TimerControls() {
         }
         confirmText="초기화하기"
         cancelText="취소"
-        onConfirm={() => removeTimer(timerId)}
+        onConfirm={() => deleteTimer(timerId)}
       />,
     );
   };

--- a/components/timer/timer-display.tsx
+++ b/components/timer/timer-display.tsx
@@ -1,32 +1,88 @@
+"use client";
+
 import TimerSeperator from "@/assets/icons/timer-seperator.svg";
-import { Fragment } from "react";
+import { useTimerStore } from "@/store/use-timer-store";
+import { sumSplits } from "@/utils/day-splits";
+import { formatElapsed } from "@/utils/format-time";
+import { Fragment, useEffect, useState } from "react";
 
-// TODO: useTimerStore의 경과 시간을 h/m/s로 포맷해 주입
-const TIMER_UNITS = [
-  { label: "HOURS", value: "00" },
-  { label: "MINUTES", value: "00" },
-  { label: "SECONDS", value: "00" },
-] as const;
-
+// 경과 시간을 HH:MM:SS 세그먼트로 보여주는 타이머 표시부.
+// 시간의 원천은 useTimerStore이며, 이 컴포넌트는 값을 "소유"하지 않고 매 렌더마다
+// 파생 계산만 한다. 상태(running/paused/idle)와 재생 제어는 각각 timer-bootstrap의
+// 복구, timer-controls의 버튼이 담당한다.
 export default function TimerDisplay() {
+  // 시계 원천값. baseMs=일자별 확정 누적치 합(ms), anchorMs=현재 running 구간의
+  // 시작 시각. 자세한 의미는 store/use-timer-store.ts 참고.
+  const status = useTimerStore((s) => s.status);
+  const baseMs = useTimerStore((s) => sumSplits(s.splits));
+  const anchorMs = useTimerStore((s) => s.anchorMs);
+
+  // now는 리렌더마다 현재 시각을 반영하기 위한 값일 뿐, 경과 시간을 누적하지 않는다.
+  // 경과값은 아래에서 (baseMs + now - anchorMs)로 그때그때 파생하므로, 이 state는
+  // "다시 계산하도록 리렌더를 트리거"하는 역할만 한다.
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    // running일 때만 시계가 흐르므로 그때만 갱신 루프를 돈다.
+    // (paused/idle이면 elapsedMs가 baseMs로 고정이라 리렌더가 필요 없다.)
+    if (status !== "running") return;
+
+    const rerender = () => setNow(Date.now());
+    const id = setInterval(rerender, 1000);
+    document.addEventListener("visibilitychange", rerender); // 탭 복귀 시 즉시 갱신
+
+    // 탭을 떠날 때(새로고침·닫기) 진행분을 baseMs로 접어 paused로 저장한다.
+    // → localStorage에 정확한 누적치가 동기 반영되고, 재방문 시 오프라인 gap 없이
+    //   그 시점 시간에서 복구된다.
+    const foldOnLeave = () => useTimerStore.getState().pause();
+    window.addEventListener("pagehide", foldOnLeave);
+
+    return () => {
+      clearInterval(id);
+      document.removeEventListener("visibilitychange", rerender);
+      window.removeEventListener("pagehide", foldOnLeave);
+    };
+  }, [status]);
+
+  // 화면에 표시할 총 경과 시간(ms).
+  // - running: 확정 누적치(baseMs)에 현재 흐르는 구간의 길이(now - anchorMs)를 더한다.
+  // - paused/idle: 흐르는 구간이 없으므로 baseMs 그대로.
+  // 구간 길이는 0으로 클램프한다: resume 직후 첫 tick(최대 1초) 전까지는 now가
+  // stale이라 (now - anchorMs)가 음수일 수 있는데, 그 동안은 baseMs(정지 시점 값)를
+  // 그대로 보여줘야 하기 때문이다. 이후 tick에서 now가 갱신되며 자연히 증가한다.
+  const runningMs =
+    status === "running" && anchorMs ? Math.max(0, now - anchorMs) : 0;
+  const elapsedMs = baseMs + runningMs;
+  // ms를 2자리 시/분/초 문자열로 분해(utils/format-time.ts).
+  const { hours, minutes, seconds } = formatElapsed(elapsedMs);
+
+  const units = [
+    { label: "HOURS", value: hours },
+    { label: "MINUTES", value: minutes },
+    { label: "SECONDS", value: seconds },
+  ] as const;
+
   return (
     <div className="flex items-center gap-6">
-      {TIMER_UNITS.map((unit, index) => (
+      {units.map((unit, index) => (
         <Fragment key={unit.label}>
           <div className="flex flex-col items-center gap-6 rounded-xl border border-primary-light-30 bg-primary-light-10 px-12 py-8">
+            {/* 7세그먼트 LED 느낌: "88"을 흐리게 깔아 꺼진 세그먼트 잔상을 만들고,
+                그 위에 실제 값을 겹쳐 켜진 세그먼트처럼 보이게 한다. 두 span의
+                자릿수/폰트가 같아야 정확히 겹친다. */}
             <div className="relative inline-block font-digital text-8xl leading-none">
-              {/* 꺼진 세그먼트 잔상 */}
+              {/* 꺼진 세그먼트 잔상 (스크린리더에는 숨김) */}
               <span aria-hidden className="text-primary-10">
                 88
               </span>
-              {/* 실제 값 */}
+              {/* 실제 값 — absolute로 잔상 위에 정확히 포갠다 */}
               <span className="absolute inset-0 text-primary">{unit.value}</span>
             </div>
             <span className="text-caption font-semibold uppercase tracking-[0.35em] text-primary">
               {unit.label}
             </span>
           </div>
-          {index < TIMER_UNITS.length - 1 && (
+          {index < units.length - 1 && (
             <TimerSeperator className="mb-10 h-14 w-3 text-primary" />
           )}
         </Fragment>

--- a/components/timer/timer-header.tsx
+++ b/components/timer/timer-header.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useProfileStore } from "@/store/use-profile-store";
+import { useSessionStore } from "@/store/use-session-store";
+import { useTimerStore } from "@/store/use-timer-store";
 
 // 타이머 뷰 상단 제목 영역.
-// TODO: 세션 진행 중이면 설정한 학습 목표(useSessionStore.goal)를 표시
 export default function TimerHeader() {
   const profile = useProfileStore((state) => state.profile);
+  const status = useTimerStore((state) => state.status);
+  const goal = useSessionStore((state) => state.goal);
 
   if (!profile) {
     return (
@@ -18,6 +21,11 @@ export default function TimerHeader() {
         </p>
       </div>
     );
+  }
+
+  // 활성 타이머(복구/진행 중)가 있으면 설정된 오늘의 목표를 제목으로 보여준다.
+  if (status !== "idle" && goal) {
+    return <h1 className="text-7xl font-bold text-indigo">{goal}</h1>;
   }
 
   return (

--- a/components/timer/todo/todo-card.tsx
+++ b/components/timer/todo/todo-card.tsx
@@ -59,6 +59,7 @@ export default function TodoCard({
         <input
           autoFocus
           value={value}
+          maxLength={30} // 할 일 항목은 최대 30자
           onChange={(e) => onChange?.(e.target.value)}
           onKeyDown={(e) => {
             // IME 조합 중 Enter(한글 확정)는 무시

--- a/components/timer/todo/todo-input.tsx
+++ b/components/timer/todo/todo-input.tsx
@@ -19,6 +19,7 @@ export default function TodoInput({
   onAdd,
   className,
   id: idProp,
+  maxLength = 30, // 할 일 항목은 최대 30자
   ...props
 }: TodoInputProps) {
   const generatedId = useId();
@@ -46,6 +47,7 @@ export default function TodoInput({
             id={id}
             placeholder={placeholder}
             value={value}
+            maxLength={maxLength}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
               // IME 조합 중 Enter(한글 확정)는 무시해 중복 추가 방지

--- a/constants/endpoints.ts
+++ b/constants/endpoints.ts
@@ -6,4 +6,6 @@ export const ENDPOINTS = {
   PRESIGNED_URL: "file/presigned-url",
   PROFILE: "profile",
   TECH_STACKS: "tech-stacks",
+  TIMERS: "timers",
+  STUDY_LOGS: "study-logs",
 } as const;

--- a/constants/query-keys.ts
+++ b/constants/query-keys.ts
@@ -1,0 +1,5 @@
+// react-query 쿼리 키를 한곳에 모아 오타·드리프트를 막는다.
+export const timerKeys = {
+  active: ["timer"] as const, // GET /api/timers (미종료 타이머)
+  studyLog: (studyLogId: string) => ["study-log", studyLogId] as const,
+};

--- a/hooks/queries/use-active-timer.ts
+++ b/hooks/queries/use-active-timer.ts
@@ -1,0 +1,22 @@
+import { getTimer } from "@/apis/timers";
+import { timerKeys } from "@/constants/query-keys";
+import { useAuthStore } from "@/store/use-auth-store";
+import { useQuery } from "@tanstack/react-query";
+
+// 미종료 타이머 조회. 진입 시 1회 복구용이라 이후 refetch를 끈다
+// (로컬 시계 상태를 서버 응답으로 덮어쓰지 않도록).
+export const useActiveTimer = () => {
+  const accessToken = useAuthStore((s) => s.accessToken);
+
+  const { data } = useQuery({
+    queryKey: timerKeys.active,
+    queryFn: getTimer,
+    enabled: !!accessToken, // silent refresh로 토큰이 채워진 뒤에만 조회
+    retry: false,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  return { timer: data };
+};

--- a/hooks/queries/use-active-timer.ts
+++ b/hooks/queries/use-active-timer.ts
@@ -2,8 +2,9 @@ import { getTimer } from "@/apis/timers";
 import { timerKeys } from "@/constants/query-keys";
 import { useAuthStore } from "@/store/use-auth-store";
 import { useQuery } from "@tanstack/react-query";
+import { HTTPError } from "ky";
 
-// 미종료 타이머 조회. 진입 시 1회 복구용이라 이후 refetch를 끈다
+// 미종료 타이머 조회. 진입 시 1회 복구용이라 이후 refetch는 끈다
 // (로컬 시계 상태를 서버 응답으로 덮어쓰지 않도록).
 export const useActiveTimer = () => {
   const accessToken = useAuthStore((s) => s.accessToken);
@@ -12,7 +13,15 @@ export const useActiveTimer = () => {
     queryKey: timerKeys.active,
     queryFn: getTimer,
     enabled: !!accessToken, // silent refresh로 토큰이 채워진 뒤에만 조회
-    retry: false,
+    // "미종료 타이머 없음"(4xx)은 정상 상황이라 재시도하지 않고 idle로 랜딩한다.
+    // 반면 일시적 네트워크/서버 오류(5xx·단절)는 재시도해 복구 신뢰성을 높인다.
+    // (retry: false로 뭉뚱그리면 일시 실패가 영구 실패가 되어 세션을 놓친다)
+    retry: (failureCount, error) => {
+      if (error instanceof HTTPError && error.response.status < 500) {
+        return false;
+      }
+      return failureCount < 3;
+    },
     staleTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/hooks/queries/use-delete-timer.ts
+++ b/hooks/queries/use-delete-timer.ts
@@ -1,0 +1,24 @@
+import { deleteTimer } from "@/apis/timers";
+import { timerKeys } from "@/constants/query-keys";
+import { resetTimerSession } from "@/store/reset-timer-session";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+// 타이머 초기화(DELETE /api/timers/{timerId}).
+// 서버에서 지워진 뒤에만 로컬을 비운다 — 먼저 비우면 삭제 실패 시 서버에 타이머가
+// 남아 다음 진입에서 되살아난다.
+export const useDeleteTimer = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (timerId: string) => deleteTimer(timerId),
+    onSuccess: () => {
+      resetTimerSession();
+      queryClient.removeQueries({ queryKey: timerKeys.active });
+    },
+    onError: (error) => {
+      console.error("타이머 초기화 실패:", error);
+    },
+  });
+
+  return { deleteTimer: mutate, isPending };
+};

--- a/hooks/queries/use-delete-timer.ts
+++ b/hooks/queries/use-delete-timer.ts
@@ -1,13 +1,17 @@
 import { deleteTimer } from "@/apis/timers";
+import AlertModal from "@/components/common/modal/alert-modal";
 import { timerKeys } from "@/constants/query-keys";
 import { resetTimerSession } from "@/store/reset-timer-session";
+import { useModalStore } from "@/store/use-modal-store";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createElement } from "react";
 
 // 타이머 초기화(DELETE /api/timers/{timerId}).
 // 서버에서 지워진 뒤에만 로컬을 비운다 — 먼저 비우면 삭제 실패 시 서버에 타이머가
 // 남아 다음 진입에서 되살아난다.
 export const useDeleteTimer = () => {
   const queryClient = useQueryClient();
+  const open = useModalStore((s) => s.open);
 
   const { mutate, isPending } = useMutation({
     mutationFn: (timerId: string) => deleteTimer(timerId),
@@ -15,8 +19,14 @@ export const useDeleteTimer = () => {
       resetTimerSession();
       queryClient.removeQueries({ queryKey: timerKeys.active });
     },
-    onError: (error) => {
-      console.error("타이머 초기화 실패:", error);
+    onError: () => {
+      // 실패 시 초기화된 것으로 오인하지 않도록 알린다. (로컬 상태는 그대로 유지)
+      open(
+        createElement(AlertModal, {
+          title: "타이머를 초기화하지 못했어요",
+          description: "잠시 후 다시 시도해 주세요.",
+        }),
+      );
     },
   });
 

--- a/hooks/queries/use-logout.ts
+++ b/hooks/queries/use-logout.ts
@@ -1,8 +1,7 @@
 import { logout } from "@/apis/auth";
+import { resetTimerSession } from "@/store/reset-timer-session";
 import { useAuthStore } from "@/store/use-auth-store";
 import { useProfileStore } from "@/store/use-profile-store";
-import { useSessionStore } from "@/store/use-session-store";
-import { useTimerStore } from "@/store/use-timer-store";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export const useLogout = () => {
@@ -25,10 +24,7 @@ export const useLogout = () => {
 
       // 타이머/세션 상태와 localStorage 저장분까지 비워 다음 사용자에게
       // 이전 타이머가 복구되지 않도록 한다.
-      useTimerStore.getState().reset();
-      useSessionStore.getState().reset();
-      useTimerStore.persist.clearStorage();
-      useSessionStore.persist.clearStorage();
+      resetTimerSession();
 
       // 쿼리 캐시도 비운다. timer/study-log는 staleTime이 Infinity라
       // 남겨두면 재로그인 시 이전 사용자의 캐시가 그대로 쓰인다.

--- a/hooks/queries/use-logout.ts
+++ b/hooks/queries/use-logout.ts
@@ -1,11 +1,14 @@
 import { logout } from "@/apis/auth";
 import { useAuthStore } from "@/store/use-auth-store";
 import { useProfileStore } from "@/store/use-profile-store";
-import { useMutation } from "@tanstack/react-query";
+import { useSessionStore } from "@/store/use-session-store";
+import { useTimerStore } from "@/store/use-timer-store";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export const useLogout = () => {
   const setAuth = useAuthStore((state) => state.setAuth);
   const clearProfile = useProfileStore((state) => state.clearProfile);
+  const queryClient = useQueryClient();
 
   const { mutate } = useMutation({
     mutationFn: async () => {
@@ -19,6 +22,17 @@ export const useLogout = () => {
         isDuplicateLogin: false,
       });
       clearProfile();
+
+      // 타이머/세션 상태와 localStorage 저장분까지 비워 다음 사용자에게
+      // 이전 타이머가 복구되지 않도록 한다.
+      useTimerStore.getState().reset();
+      useSessionStore.getState().reset();
+      useTimerStore.persist.clearStorage();
+      useSessionStore.persist.clearStorage();
+
+      // 쿼리 캐시도 비운다. timer/study-log는 staleTime이 Infinity라
+      // 남겨두면 재로그인 시 이전 사용자의 캐시가 그대로 쓰인다.
+      queryClient.clear();
     },
     onError: (error) => {
       console.error("Logout failed:", error);

--- a/hooks/queries/use-start-timer.ts
+++ b/hooks/queries/use-start-timer.ts
@@ -1,0 +1,22 @@
+import { startTimer } from "@/apis/timers";
+import { useSessionStore } from "@/store/use-session-store";
+import { useTimerStore } from "@/store/use-timer-store";
+import type { StartTimerRequest } from "@/types/request";
+import { useMutation } from "@tanstack/react-query";
+
+// 새 타이머 시작(POST /api/timers). 성공 시에만 응답의 서버 신원(timerId/studyLogId)을
+// 시계에 주입하고 running으로 전환한다. 모달 닫기 등 UI는 호출부 onSuccess로.
+export const useStartTimer = () => {
+  const start = useTimerStore((s) => s.start);
+  const setPhase = useSessionStore((s) => s.setPhase);
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: StartTimerRequest) => startTimer(data),
+    onSuccess: ({ timerId, studyLogId }) => {
+      start({ timerId, studyLogId });
+      setPhase("running");
+    },
+  });
+
+  return { startTimer: mutate, isPending };
+};

--- a/hooks/queries/use-start-timer.ts
+++ b/hooks/queries/use-start-timer.ts
@@ -1,20 +1,33 @@
 import { startTimer } from "@/apis/timers";
+import AlertModal from "@/components/common/modal/alert-modal";
+import { useModalStore } from "@/store/use-modal-store";
 import { useSessionStore } from "@/store/use-session-store";
 import { useTimerStore } from "@/store/use-timer-store";
 import type { StartTimerRequest } from "@/types/request";
 import { useMutation } from "@tanstack/react-query";
+import { createElement } from "react";
 
 // 새 타이머 시작(POST /api/timers). 성공 시에만 응답의 서버 신원(timerId/studyLogId)을
 // 시계에 주입하고 running으로 전환한다. 모달 닫기 등 UI는 호출부 onSuccess로.
 export const useStartTimer = () => {
   const start = useTimerStore((s) => s.start);
   const setPhase = useSessionStore((s) => s.setPhase);
+  const open = useModalStore((s) => s.open);
 
   const { mutate, isPending } = useMutation({
     mutationFn: (data: StartTimerRequest) => startTimer(data),
     onSuccess: ({ timerId, studyLogId }) => {
       start({ timerId, studyLogId });
       setPhase("running");
+    },
+    onError: () => {
+      // 실패 시 조용히 끝나지 않도록 사용자에게 알린다. (로컬 상태는 idle 유지)
+      open(
+        createElement(AlertModal, {
+          title: "타이머를 시작하지 못했어요",
+          description: "잠시 후 다시 시도해 주세요.",
+        }),
+      );
     },
   });
 

--- a/hooks/queries/use-stop-timer.ts
+++ b/hooks/queries/use-stop-timer.ts
@@ -1,14 +1,18 @@
 import { stopTimer } from "@/apis/timers";
+import AlertModal from "@/components/common/modal/alert-modal";
 import { timerKeys } from "@/constants/query-keys";
 import { resetTimerSession } from "@/store/reset-timer-session";
+import { useModalStore } from "@/store/use-modal-store";
 import { useTimerStore } from "@/store/use-timer-store";
 import type { StopTimerRequest } from "@/types/request";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createElement } from "react";
 
 // 타이머 종료/세션 확정(POST /api/timers/{timerId}/stop).
 // 성공 시 로컬 상태·저장분을 비우고 캐시를 제거한다. 모달 닫기는 호출부 onSuccess로.
 export const useStopTimer = () => {
   const queryClient = useQueryClient();
+  const open = useModalStore((s) => s.open);
 
   const { mutate, isPending } = useMutation({
     mutationFn: (payload: StopTimerRequest) => {
@@ -20,6 +24,15 @@ export const useStopTimer = () => {
       resetTimerSession();
       // 종료된 타이머가 부트스트랩에서 다시 복구되지 않도록 캐시 제거.
       queryClient.removeQueries({ queryKey: timerKeys.active });
+    },
+    onError: () => {
+      // 실패 시 세션이 저장된 것으로 오인하지 않도록 알린다. (로컬 세션은 그대로 유지)
+      open(
+        createElement(AlertModal, {
+          title: "학습 기록을 저장하지 못했어요",
+          description: "잠시 후 다시 시도해 주세요.",
+        }),
+      );
     },
   });
 

--- a/hooks/queries/use-stop-timer.ts
+++ b/hooks/queries/use-stop-timer.ts
@@ -1,0 +1,27 @@
+import { stopTimer } from "@/apis/timers";
+import { timerKeys } from "@/constants/query-keys";
+import { resetTimerSession } from "@/store/reset-timer-session";
+import { useTimerStore } from "@/store/use-timer-store";
+import type { StopTimerRequest } from "@/types/request";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+// 타이머 종료/세션 확정(POST /api/timers/{timerId}/stop).
+// 성공 시 로컬 상태·저장분을 비우고 캐시를 제거한다. 모달 닫기는 호출부 onSuccess로.
+export const useStopTimer = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (payload: StopTimerRequest) => {
+      const timerId = useTimerStore.getState().timerId;
+      if (!timerId) throw new Error("종료할 타이머가 없습니다.");
+      return stopTimer(timerId, payload);
+    },
+    onSuccess: () => {
+      resetTimerSession();
+      // 종료된 타이머가 부트스트랩에서 다시 복구되지 않도록 캐시 제거.
+      queryClient.removeQueries({ queryKey: timerKeys.active });
+    },
+  });
+
+  return { stopTimer: mutate, isPending };
+};

--- a/hooks/queries/use-study-log.ts
+++ b/hooks/queries/use-study-log.ts
@@ -1,0 +1,17 @@
+import { getStudyLog } from "@/apis/study-logs";
+import { timerKeys } from "@/constants/query-keys";
+import { useQuery } from "@tanstack/react-query";
+
+// 미종료 타이머의 세션 내용(목표·할 일·회고) 조회. studyLogId가 있을 때만 조회한다.
+export const useStudyLog = (studyLogId: string | undefined) => {
+  const { data } = useQuery({
+    queryKey: timerKeys.studyLog(studyLogId ?? ""),
+    queryFn: () => getStudyLog(studyLogId!),
+    enabled: !!studyLogId,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  return { studyLog: data };
+};

--- a/hooks/queries/use-sync-timer.ts
+++ b/hooks/queries/use-sync-timer.ts
@@ -1,0 +1,20 @@
+import { updateTimer } from "@/apis/timers";
+import { useTimerStore } from "@/store/use-timer-store";
+import { useMutation } from "@tanstack/react-query";
+
+// 현재까지의 일자별 경과를 서버에 동기화한다(PUT /api/timers/{timerId}).
+// 일시정지 시점 반영과 폴링(heartbeat)에서 공용으로 쓴다.
+export const useSyncTimer = () => {
+  const { mutate } = useMutation({
+    mutationFn: (timerId: string) =>
+      updateTimer(timerId, {
+        splitTimes: useTimerStore.getState().getSplitTimesSnapshot(),
+      }),
+    onError: (error) => {
+      // 동기화 실패해도 로컬 상태는 유지된다(다음 동기화/종료 때 재반영).
+      console.error("타이머 동기화 실패:", error);
+    },
+  });
+
+  return { syncTimer: mutate };
+};

--- a/hooks/queries/use-update-study-log.ts
+++ b/hooks/queries/use-update-study-log.ts
@@ -1,0 +1,20 @@
+import { updateStudyLog } from "@/apis/study-logs";
+import { useTimerStore } from "@/store/use-timer-store";
+import type { UpdateStudyLogRequest } from "@/types/request";
+import { useMutation } from "@tanstack/react-query";
+
+// 할 일 목록을 서버에 저장한다(PUT /api/study-logs/{studyLogId}/tasks).
+export const useUpdateStudyLog = () => {
+  const { mutate, isPending } = useMutation({
+    mutationFn: (tasks: UpdateStudyLogRequest["tasks"]) => {
+      const studyLogId = useTimerStore.getState().studyLogId;
+      if (!studyLogId) throw new Error("저장할 학습 로그가 없습니다.");
+      return updateStudyLog(studyLogId, { tasks });
+    },
+    onError: (error) => {
+      console.error("할 일 목록 저장 실패:", error);
+    },
+  });
+
+  return { updateStudyLog: mutate, isPending };
+};

--- a/hooks/use-timer-heartbeat.ts
+++ b/hooks/use-timer-heartbeat.ts
@@ -1,29 +1,22 @@
-import { updateTimer } from "@/apis/timers";
+import { useSyncTimer } from "@/hooks/queries/use-sync-timer";
 import { useTimerStore } from "@/store/use-timer-store";
 import { useEffect } from "react";
 
 const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000; // 10분
 
 // 타이머 상태 중간 업데이트(폴링).
-// - running 중 10분마다 현재까지의 일자별 경과를 PUT /api/timers/{timerId}로 동기화
+// - running 중 10분마다 현재까지의 일자별 경과를 서버에 동기화(useSyncTimer)
 // - paused/idle로 바뀌면 effect cleanup이 인터벌을 정리해 폴링이 멈춘다
 // - 다시 재생하면 status가 running으로 바뀌며 새 인터벌이 시작된다(재생 시점부터 10분)
 export function useTimerHeartbeat() {
   const status = useTimerStore((s) => s.status);
   const timerId = useTimerStore((s) => s.timerId);
+  const { syncTimer } = useSyncTimer();
 
   useEffect(() => {
     if (status !== "running" || !timerId) return;
 
-    const id = setInterval(() => {
-      updateTimer(timerId, {
-        splitTimes: useTimerStore.getState().getSplitTimesSnapshot(),
-      }).catch((error) => {
-        // 동기화 실패는 UI를 막지 않고 다음 주기/일시정지/종료 때 재반영된다.
-        console.error("타이머 폴링 동기화 실패:", error);
-      });
-    }, HEARTBEAT_INTERVAL_MS);
-
+    const id = setInterval(() => syncTimer(timerId), HEARTBEAT_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [status, timerId]);
+  }, [status, timerId, syncTimer]);
 }

--- a/hooks/use-timer-heartbeat.ts
+++ b/hooks/use-timer-heartbeat.ts
@@ -1,0 +1,29 @@
+import { updateTimer } from "@/apis/timers";
+import { useTimerStore } from "@/store/use-timer-store";
+import { useEffect } from "react";
+
+const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000; // 10분
+
+// 타이머 상태 중간 업데이트(폴링).
+// - running 중 10분마다 현재까지의 일자별 경과를 PUT /api/timers/{timerId}로 동기화
+// - paused/idle로 바뀌면 effect cleanup이 인터벌을 정리해 폴링이 멈춘다
+// - 다시 재생하면 status가 running으로 바뀌며 새 인터벌이 시작된다(재생 시점부터 10분)
+export function useTimerHeartbeat() {
+  const status = useTimerStore((s) => s.status);
+  const timerId = useTimerStore((s) => s.timerId);
+
+  useEffect(() => {
+    if (status !== "running" || !timerId) return;
+
+    const id = setInterval(() => {
+      updateTimer(timerId, {
+        splitTimes: useTimerStore.getState().getSplitTimesSnapshot(),
+      }).catch((error) => {
+        // 동기화 실패는 UI를 막지 않고 다음 주기/일시정지/종료 때 재반영된다.
+        console.error("타이머 폴링 동기화 실패:", error);
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, [status, timerId]);
+}

--- a/store/reset-timer-session.ts
+++ b/store/reset-timer-session.ts
@@ -1,0 +1,12 @@
+import { useSessionStore } from "./use-session-store";
+import { useTimerStore } from "./use-timer-store";
+
+// 타이머 세션의 로컬 상태(시계 + 세션 내용)와 localStorage 저장분을 일괄 초기화한다.
+// 종료(stop)·초기화(delete)·로그아웃에서 공통으로 쓴다.
+// (react-query 캐시 정리는 QueryClient가 필요하므로 호출부에서 별도 처리)
+export const resetTimerSession = () => {
+  useTimerStore.getState().reset();
+  useSessionStore.getState().reset();
+  useTimerStore.persist.clearStorage();
+  useSessionStore.persist.clearStorage();
+};

--- a/store/use-session-store.ts
+++ b/store/use-session-store.ts
@@ -1,4 +1,6 @@
+import type { GetStudyLogsResponse } from "@/types/response";
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 // 학습 세션의 국면. 같은 TodoList를 국면별로 다르게 파생시켜 보여준다.
 export type SessionPhase = "setup" | "running" | "review" | "record";
@@ -26,6 +28,8 @@ interface SessionState {
   deleteTodo: (id: string) => void;
   toggleTodo: (id: string) => void;
   setReflection: (reflection: string) => void;
+  // 미종료 세션 복구: GET /api/study-logs/{studyLogId} 결과로 세션 내용을 채운다.
+  hydrateFromStudyLog: (data: GetStudyLogsResponse["data"]) => void;
   reset: () => void;
 }
 
@@ -37,10 +41,14 @@ const initialState = {
   editingId: null as string | null,
 };
 
-export const useSessionStore = create<SessionState>((set) => ({
-  ...initialState,
+// 세션 내용(목표·할 일·회고)도 새로고침에 살아남도록 저장한다. 시계(useTimerStore)와
+// 짝을 이뤄, 로컬에 세션이 살아있으면 부트스트랩이 서버 값으로 덮어쓰지 않는다.
+export const useSessionStore = create<SessionState>()(
+  persist(
+    (set) => ({
+      ...initialState,
 
-  setPhase: (phase) => set({ phase }),
+      setPhase: (phase) => set({ phase }),
   setGoal: (goal) => set({ goal }),
 
   addTodo: (content) =>
@@ -70,5 +78,31 @@ export const useSessionStore = create<SessionState>((set) => ({
     })),
 
   setReflection: (reflection) => set({ reflection }),
-  reset: () => set(initialState),
-}));
+
+  hydrateFromStudyLog: (data) =>
+    set({
+      phase: "running",
+      goal: data.todayGoal,
+      todos: data.tasks.map((t) => ({
+        id: t.id,
+        content: t.content,
+        done: t.isCompleted,
+      })),
+      reflection: data.review ?? "",
+    }),
+
+      reset: () => set(initialState),
+    }),
+    {
+      name: "devtime-session",
+      skipHydration: true,
+      // 편집 중 UI 상태(editingId)는 저장하지 않는다.
+      partialize: (s) => ({
+        phase: s.phase,
+        goal: s.goal,
+        todos: s.todos,
+        reflection: s.reflection,
+      }),
+    },
+  ),
+);

--- a/store/use-timer-store.ts
+++ b/store/use-timer-store.ts
@@ -1,0 +1,140 @@
+import type { GetTimerResponse, StartTimerResponse } from "@/types/response";
+import {
+  arrayToSplits,
+  dayKey,
+  foldSegment,
+  splitsToArray,
+  sumSplits,
+} from "@/utils/day-splits";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+// 시계의 재생 상태. 세션 내용(goal·todos)은 useSessionStore가 따로 관리한다.
+export type TimerStatus = "idle" | "running" | "paused";
+
+interface TimerState {
+  status: TimerStatus;
+  timerId: string | null;
+  studyLogId: string | null;
+  // 일자별 확정 누적 경과(ms). key는 로컬 날짜("YYYY-MM-DD").
+  // 이미 끝난(=일시정지로 접힌) 구간들의 일자별 합이다. 진행 중 구간은 미포함.
+  splits: Record<string, number>;
+  // 현재 running 구간이 시작된 클라이언트 시각(Date.now(), ms). paused/idle이면 null.
+  anchorMs: number | null;
+
+  // GET /api/timers 결과로 미종료 타이머를 복구한다.
+  // 브라우저가 닫혀 있던 오프라인 구간은 학습 시간이 아니므로 포함하지 않고,
+  // paused로 랜딩해 사용자가 재개하게 한다.
+  hydrateFromServer: (res: GetTimerResponse) => void;
+
+  // 새 세션 시작(0부터). POST /api/timers 응답의 서버 신원을 함께 저장한다.
+  start: (init: Pick<StartTimerResponse, "timerId" | "studyLogId">) => void;
+  pause: () => void;
+  resume: () => void;
+  reset: () => void;
+
+  // 화면 표시용 총 경과 시간(ms). tick으로 누적하지 않고 항상 시각차로 파생한다.
+  getElapsedMs: () => number;
+
+  // 서버로 보낼 일자별 splitTimes 배열. splits 복사본에 현재 진행 구간을 접어
+  // 넣어 만든다(스토어는 변경하지 않음 → 폴링 반복에 멱등). pause·폴링·종료 공용.
+  getSplitTimesSnapshot: () => { date: string; timeSpent: number }[];
+}
+
+const initialState = {
+  status: "idle" as TimerStatus,
+  timerId: null,
+  studyLogId: null,
+  splits: {} as Record<string, number>,
+  anchorMs: null,
+};
+
+// 폴링이 없어도 새로고침으로 메모리가 날아가면 시계가 유지되도록 localStorage에
+// 저장한다. SSR 하이드레이션 불일치를 피하려고 skipHydration을 켜고, 클라이언트
+// 마운트 후 명시적으로 rehydrate한다(components/timer/timer-bootstrap.tsx).
+export const useTimerStore = create<TimerState>()(
+  persist(
+    (set, get) => ({
+      ...initialState,
+
+      hydrateFromServer: (res) =>
+        set({
+          status: "paused",
+          timerId: res.timerId,
+          studyLogId: res.studyLogId,
+          splits: arrayToSplits(res.splitTimes),
+          anchorMs: null,
+        }),
+
+      start: ({ timerId, studyLogId }) =>
+        set({
+          status: "running",
+          splits: {},
+          anchorMs: Date.now(),
+          timerId,
+          studyLogId,
+        }),
+
+      pause: () =>
+        set((state) => {
+          if (state.status !== "running" || state.anchorMs === null)
+            return state;
+          // 진행 중이던 구간을 일자별로 잘라 splits에 커밋한다.
+          const splits = { ...state.splits };
+          foldSegment(splits, state.anchorMs, Date.now());
+          return { status: "paused", splits, anchorMs: null };
+        }),
+
+      resume: () =>
+        set((state) =>
+          state.status === "paused"
+            ? { status: "running", anchorMs: Date.now() }
+            : state,
+        ),
+
+      reset: () => set(initialState),
+
+      getElapsedMs: () => {
+        const { splits, status, anchorMs } = get();
+        return (
+          sumSplits(splits) +
+          (status === "running" && anchorMs ? Date.now() - anchorMs : 0)
+        );
+      },
+
+      getSplitTimesSnapshot: () => {
+        const { splits, status, anchorMs } = get();
+        const buckets = { ...splits };
+        if (status === "running" && anchorMs) {
+          foldSegment(buckets, anchorMs, Date.now());
+        }
+        return splitsToArray(buckets);
+      },
+    }),
+    {
+      name: "devtime-timer",
+      version: 1, // baseMs(총합) → splits(일자별)로 shape 변경
+      skipHydration: true,
+      // 시계 상태만 저장한다(액션 제외).
+      partialize: (s) => ({
+        status: s.status,
+        timerId: s.timerId,
+        studyLogId: s.studyLogId,
+        splits: s.splits,
+        anchorMs: s.anchorMs,
+      }),
+      // 이전 버전(v0)의 baseMs를 오늘 날짜 단일 버킷으로 옮긴다.
+      migrate: (persisted, version) => {
+        if (version === 0 && persisted && typeof persisted === "object") {
+          const { baseMs, ...rest } = persisted as { baseMs?: number } & Record<
+            string,
+            unknown
+          >;
+          const splits = baseMs ? { [dayKey(Date.now())]: baseMs } : {};
+          return { ...rest, splits } as TimerState;
+        }
+        return persisted as TimerState;
+      },
+    },
+  ),
+);

--- a/store/use-timer-store.ts
+++ b/store/use-timer-store.ts
@@ -33,6 +33,11 @@ interface TimerState {
   resume: () => void;
   reset: () => void;
 
+  // 크래시·강제종료로 pagehide fold가 못 돈 흔적(재수화 시 status가 running).
+  // 신뢰할 수 없는 진행 구간(anchorMs)을 버리고 paused로 정규화한다. splits(확정
+  // 누적)는 보존하므로 마지막 확정 시점은 유지되고, 오프라인 구간만 폐기된다.
+  discardStaleRun: () => void;
+
   // 화면 표시용 총 경과 시간(ms). tick으로 누적하지 않고 항상 시각차로 파생한다.
   getElapsedMs: () => number;
 
@@ -93,6 +98,15 @@ export const useTimerStore = create<TimerState>()(
         ),
 
       reset: () => set(initialState),
+
+      // running으로 재수화된 상태 전체를 정규화한다. anchorMs가 null인 비정상
+      // 저장값도 함께 안전하게 paused로 복구된다.
+      discardStaleRun: () =>
+        set((state) =>
+          state.status === "running"
+            ? { status: "paused", anchorMs: null }
+            : state,
+        ),
 
       getElapsedMs: () => {
         const { splits, status, anchorMs } = get();

--- a/types/request.ts
+++ b/types/request.ts
@@ -30,3 +30,22 @@ export interface CreateProfileRequest {
 export interface CreateTechStackRequest {
   name: string;
 }
+
+export interface StartTimerRequest {
+  todayGoal: string;
+  tasks: string[];
+}
+
+export interface UpdateTimerRequest {
+  splitTimes: { date: string; timeSpent: number }[];
+}
+
+export interface StopTimerRequest {
+  splitTimes: { date: string; timeSpent: number }[];
+  review: string;
+  tasks: { content: string; isCompleted: boolean }[];
+}
+
+export interface UpdateStudyLogRequest {
+  tasks: { content: string; isCompleted: boolean }[];
+}

--- a/types/response.ts
+++ b/types/response.ts
@@ -8,6 +8,7 @@ export interface BaseResponse {
 export type SignupResponse = BaseResponse;
 export type LogoutResponse = BaseResponse;
 export type CreateProfileResponse = BaseResponse;
+export type UpdateStudyLogResponse = BaseResponse;
 
 export interface CheckDuplicateResponse extends BaseResponse {
   available: boolean;
@@ -67,4 +68,45 @@ export interface TechStacksResponse {
 export interface CreateTechStackResponse {
   message: string;
   techStack: TechStack;
+}
+
+export interface GetTimerResponse {
+  timerId: string;
+  studyLogId: string;
+  splitTimes: { date: string; timeSpent: number }[];
+  startTime: string;
+  lastUpdateTime: string;
+}
+
+export interface GetStudyLogsResponse {
+  success: boolean;
+  data: {
+    id: string;
+    date: string;
+    todayGoal: string;
+    studyTime: number;
+    tasks: { id: string; content: string; isCompleted: boolean }[];
+    review: string;
+    completionRate: number;
+  };
+}
+
+export interface StartTimerResponse {
+  message: string;
+  studyLogId: string;
+  timerId: string;
+  startTime: string; // ex) "2026-07-22T05:28:04.187Z"
+}
+
+export interface UpdateTimerResponse {
+  message: string;
+  startTime: string;
+  splitTimes: { date: string; timeSpent: number }[];
+  lastUpdateTime: string;
+}
+
+export interface StopTimerResponse {
+  message: string;
+  totalTime: number;
+  endTime: string;
 }

--- a/utils/day-splits.ts
+++ b/utils/day-splits.ts
@@ -11,15 +11,11 @@ export const dayKey = (ms: number): string => {
 };
 
 // dayKey → 서버로 보낼 date 마커(ISO 문자열).
-// 날짜부는 버킷 날짜로 두되 시간부는 "현재 시각"으로 채운다. 자정(00:00:00.000Z)은
-// 타이머 시작 시각보다 이전이라 서버 검증(시작~현재 범위)에 걸릴 수 있어서다.
-// dayKey는 로컬 날짜 컴포넌트로 판정하므로 dayKey(dateMarker(k)) === k 왕복은 유지된다.
-export const dateMarker = (key: string): string => {
-  const [y, m, d] = key.split("-").map(Number);
-  const dt = new Date(); // 현재 시각(시:분:초 유지)
-  dt.setFullYear(y, m - 1, d); // 날짜부만 버킷 날짜로 교체(로컬 기준)
-  return dt.toISOString();
-};
+// 백엔드가 각 일자를 "그 날의 자정(YYYY-MM-DDT00:00:00.000Z)" 마커로 받으므로,
+// 로컬 날짜 키를 그대로 문자열에 담아 보낸다. toISOString()의 UTC 변환을 거치지
+// 않아 날짜부가 로컬 날짜 그대로 유지되고(KST 새벽에도 전날로 밀리지 않음),
+// dayKey(dateMarker(k)) === k 왕복도 성립한다.
+export const dateMarker = (key: string): string => `${key}T00:00:00.000Z`;
 
 // [startMs, endMs) 구간을 로컬 자정 경계로 잘라 buckets(일자별 ms)에 더한다.
 // 자정을 넘긴 구간도 정확히 두 날짜로 분배된다.

--- a/utils/day-splits.ts
+++ b/utils/day-splits.ts
@@ -11,10 +11,15 @@ export const dayKey = (ms: number): string => {
 };
 
 // dayKey → 서버로 보낼 date 마커(ISO 문자열).
-// 로컬 날짜를 date부에 그대로 담은 UTC 자정으로 보낸다("2026-07-24T00:00:00.000Z").
-// → 서버/분석이 date부를 slice해도 올바른 날이 읽히고, KST(+9) 등 양수 오프셋
-//   타임존에선 dayKey(dateMarker(k)) === k 로 왕복도 보존된다.
-export const dateMarker = (key: string): string => `${key}T00:00:00.000Z`;
+// 날짜부는 버킷 날짜로 두되 시간부는 "현재 시각"으로 채운다. 자정(00:00:00.000Z)은
+// 타이머 시작 시각보다 이전이라 서버 검증(시작~현재 범위)에 걸릴 수 있어서다.
+// dayKey는 로컬 날짜 컴포넌트로 판정하므로 dayKey(dateMarker(k)) === k 왕복은 유지된다.
+export const dateMarker = (key: string): string => {
+  const [y, m, d] = key.split("-").map(Number);
+  const dt = new Date(); // 현재 시각(시:분:초 유지)
+  dt.setFullYear(y, m - 1, d); // 날짜부만 버킷 날짜로 교체(로컬 기준)
+  return dt.toISOString();
+};
 
 // [startMs, endMs) 구간을 로컬 자정 경계로 잘라 buckets(일자별 ms)에 더한다.
 // 자정을 넘긴 구간도 정확히 두 날짜로 분배된다.

--- a/utils/day-splits.ts
+++ b/utils/day-splits.ts
@@ -1,0 +1,70 @@
+// 타이머 경과 시간을 "일자별"로 관리하기 위한 유틸.
+// 하루 경계는 사용자 로컬 자정 기준으로 잡는다(대시보드의 "오늘" 개념과 일치).
+
+// 어떤 시각(ms epoch)이 속한 로컬 캘린더 날짜 키. 예: "2026-07-24"
+export const dayKey = (ms: number): string => {
+  const d = new Date(ms);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+};
+
+// dayKey → 서버로 보낼 date 마커(ISO 문자열).
+// 로컬 날짜를 date부에 그대로 담은 UTC 자정으로 보낸다("2026-07-24T00:00:00.000Z").
+// → 서버/분석이 date부를 slice해도 올바른 날이 읽히고, KST(+9) 등 양수 오프셋
+//   타임존에선 dayKey(dateMarker(k)) === k 로 왕복도 보존된다.
+export const dateMarker = (key: string): string => `${key}T00:00:00.000Z`;
+
+// [startMs, endMs) 구간을 로컬 자정 경계로 잘라 buckets(일자별 ms)에 더한다.
+// 자정을 넘긴 구간도 정확히 두 날짜로 분배된다.
+export const foldSegment = (
+  buckets: Record<string, number>,
+  startMs: number,
+  endMs: number,
+): void => {
+  let cursor = startMs; // 아직 처리 안 한 구간의 시작점. cursor -->"여기 까지 처리했다."
+  while (cursor < endMs) {
+    const d = new Date(cursor);
+    // 다음 로컬 자정 (day + 1은 월/연도 경계를 Date가 알아서 넘겨준다)
+    // cursor가 속한 날의 다음 날 자정
+    const nextMidnight = new Date(
+      d.getFullYear(),
+      d.getMonth(),
+      d.getDate() + 1,
+    ).getTime();
+
+    // endMs와 nextMidnight 중 더 작은 쪽까지를 이번 chunk로 처리한다.
+    // endMs가 더 이르면 자정을 안 넘기고 구간이 끝남.
+    // nextMidnight가 더 이르면 자정에서 끊고 다음 반복으로 (아직 구간이 남음)
+    const chunkEnd = Math.min(nextMidnight, endMs);
+    const key = dayKey(cursor);
+    buckets[key] = (buckets[key] ?? 0) + (chunkEnd - cursor);
+    cursor = chunkEnd;
+  }
+};
+
+// 일자별 버킷 맵 → 서버 splitTimes 배열 (서버로 보낼 때)
+export const splitsToArray = (
+  buckets: Record<string, number>,
+): { date: string; timeSpent: number }[] =>
+  Object.entries(buckets).map(([key, timeSpent]) => ({
+    date: dateMarker(key),
+    timeSpent,
+  }));
+
+// 서버 splitTimes 배열 → 일자별 버킷 맵 (같은 날은 합산)
+export const arrayToSplits = (
+  splitTimes: { date: string; timeSpent: number }[],
+): Record<string, number> => {
+  const buckets: Record<string, number> = {};
+  for (const s of splitTimes) {
+    const key = dayKey(Date.parse(s.date));
+    buckets[key] = (buckets[key] ?? 0) + s.timeSpent;
+  }
+  return buckets;
+};
+
+// 일자별 버킷 합 = 총 경과(ms)
+export const sumSplits = (buckets: Record<string, number>): number =>
+  Object.values(buckets).reduce((sum, ms) => sum + ms, 0);

--- a/utils/format-time.ts
+++ b/utils/format-time.ts
@@ -1,0 +1,11 @@
+// 경과 시간(ms)을 타이머 표시용 HH/MM/SS 2자리 문자열로 분해한다.
+export function formatElapsed(elapsedMs: number) {
+  const totalSec = Math.max(0, Math.floor(elapsedMs / 1000));
+  const pad = (n: number) => String(n).padStart(2, "0");
+
+  return {
+    hours: pad(Math.floor(totalSec / 3600)),
+    minutes: pad(Math.floor((totalSec % 3600) / 60)),
+    seconds: pad(totalSec % 60),
+  };
+}


### PR DESCRIPTION
## 📌관련 이슈

> #21 

## 📝작업 내용
- 타이머 **시작/일시정지/재개/종료(stop)/초기화(delete)** API 연동 (초기화는 확인 모달 후 삭제)
- **미종료 타이머 복구** — 진입 시 `GET /timers` + localStorage로 새로고침·재로그인·강제종료 대응
- **10분 주기 서버 동기화(폴링)** — running 중에만 동작, 일시정지/재개에 맞춰 자동 시작·정지
- **일자별 splitTimes 관리** — 자정 경계 분할로 날짜별 학습 시간 집계 (대시보드 대비)
- **입력 제한 UI** — 목표·할일 30자 / 회고 15~500자 + 글자 수·안내 헬퍼 텍스트
- **할 일 목록 저장** — study-log(`PUT /study-logs/{id}/tasks`) 연동
- react-query 로직을 `hooks/queries/` 훅으로 분리 (컴포넌트 경량화)

## 💻 스크린샷 (선택)

## 💬코멘트 (선택)
- 경과 시간은 tick 누적이 아니라 timestamp 차이로 파생 → 비활성 탭에서도 정확


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 타이머/학습로그 서버 연동이 적용되어 시작·동기화·중지·저장·삭제 흐름이 실제로 반영됩니다.
  * 타이머가 실시간 HH:MM:SS로 표시되고, 10분마다 서버와 동기화되며 재접속 시 복원됩니다.
* **개선**
  * 목표/할 일/회고 입력에 최대 30자 제한 및 최소·최대 글자 수 안내/검증이 추가됩니다.
  * 모달 버튼 동작과 세션 헤더(“오늘의 목표”)가 타이머 상태에 맞게 조정됩니다.
  * HelperText에 중립(neutral) 스타일이 추가되고, 로그아웃 시 타이머·세션 및 로컬 저장이 함께 정리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->